### PR TITLE
Modfiy scalelab inventory to generate files on the undercloud

### DIFF
--- a/roles/scalelab-inventory/defaults/main.yml
+++ b/roles/scalelab-inventory/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-local_working_dir: /tmp/
+local_working_dir: "{{lookup('env','WORKSPACE')}}"
 working_dir: /home/stack
 ssh_user: stack
 undercloud_user: stack

--- a/roles/scalelab-inventory/tasks/main.yml
+++ b/roles/scalelab-inventory/tasks/main.yml
@@ -28,10 +28,23 @@
 
 - name: fetch the undercloud ssh key
   fetch:
-    src: '{{ working_dir }}/.ssh/id_rsa'
+    src: '/home/stack/.ssh/id_rsa'
     dest: '{{ overcloud_key }}'
     flat: yes
     mode: 0400
+
+#required for regeneration of ssh.config.ansible
+- name: set_fact for undercloud ip
+  set_fact:
+    undercloud_ip: "{{ ansible_default_ipv4.address }} "
+
+#required for regeneration of ssh.config.ansible
+- name: set undercloud ssh proxy command
+  set_fact:
+    undercloud_ssh_proxy_command: "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+      -o ConnectTimeout=60 -i {{ overcloud_key }}
+      {{ ssh_user }}@{{ hostvars['localhost'].ansible_default_ipv4.address }}
+      -W {{ undercloud_ip }}:22"
 
 # add host to the ansible group formed from its type
 # novacompute nodes are added as compute for backwards compatibility
@@ -44,39 +57,32 @@
     ansible_fqdn: '{{ item.value }}'
     ansible_user: "{{ overcloud_user | default('heat-admin') }}"
     ansible_private_key_file: "{{ overcloud_key }}"
-    ansible_ssh_common_args: '-F "{{ local_working_dir }}/ssh.config.ansible"'
-
-#required for regeneration of ssh.config.ansible
-- name: set_fact for undercloud ip
-  set_fact:
-    undercloud_ip: "{{ ansible_default_ipv4.address }} "
-    cacheable: true
-
-#required for regeneration of ssh.config.ansible
-- name: set undercloud ssh proxy command
-  set_fact:
-    undercloud_ssh_proxy_command: "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
-      -o ConnectTimeout=60 -i {{ local_working_dir }}/id_rsa_virt_power
-      {{ ssh_user }}@{{ hostvars['localhost'].ansible_default_ipv4.address }}
-      -W {{ undercloud_ip }}:22"
-    cacheable: true
+    ansible_ssh_common_args: ' -F {{local_working_dir}}/ssh.config.ansible'
 
 - name: create inventory from template
-  delegate_to: localhost
   template:
     src: 'inventory.j2'
-    dest: '{{ local_working_dir }}/hosts'
+    dest: '{{working_dir}}/hosts'
 
 - name: regenerate ssh config
-  delegate_to: localhost
   template:
     src: 'ssh_config.j2'
-    dest: '{{ local_working_dir }}/ssh.config.ansible'
+    dest: '{{working_dir}}/ssh.config.ansible'
     mode: 0644
+
+- name: Fetch hosts
+  fetch:
+    flat: yes
+    src: "{{working_dir}}/hosts"
+    dest: "{{local_working_dir}}/hosts"
+
+- name: Fetch ssh config
+  fetch:
+    flat: yes
+    src: "{{working_dir}}/ssh.config.ansible"
+    dest: "{{local_working_dir}}/ssh.config.ansible"
 
 # just setup the ssh.config.ansible and hosts file for the undercloud
 - name: check for existence of identity key
   delegate_to: localhost
-  stat: path="{{ local_working_dir }}/id_rsa_virt_power"
-  when: undercloud_ip is not defined
-  register: result_stat_id_rsa_virt_power
+  stat: path="{{overcloud_key}}"

--- a/roles/scalelab-inventory/templates/ssh_config.j2
+++ b/roles/scalelab-inventory/templates/ssh_config.j2
@@ -7,14 +7,14 @@ Host undercloud-root
 {% else %}
     Hostname {{ undercloud_ip }}
 {% endif %}
-    IdentityFile {{lookup('env', 'HOME')}}/.ssh/id_rsa
+    IdentityFile {{ansible_ssh_private_key_file}}
     User root
     StrictHostKeyChecking no
     UserKnownHostsFile=/dev/null
 
 Host undercloud
     Hostname {{ undercloud_ip }}
-    IdentityFile {{lookup('env', 'HOME')}}/.ssh/id_rsa
+    IdentityFile {{ansible_ssh_private_key_file}}
     User {{ undercloud_user }}
     StrictHostKeyChecking no
     UserKnownHostsFile=/dev/null

--- a/roles/undercloud-prepare-host/defaults/main.yml
+++ b/roles/undercloud-prepare-host/defaults/main.yml
@@ -8,3 +8,4 @@ utilities:
   - python-virtualenv
   - libguestfs-tools
   - gcc
+  - libselinux-python


### PR DESCRIPTION
Not only is the Jenkins slave not really accesible, it runs into
the selinux-python issue when trying to template these files
locally. Instead we will put them on the undercloud where someone
might actually find them useful.

This turned into a significant rethinking of where credentials
should come from. Morroring the earlier refactoring I had to do
after moving to the openshift jenkins