### PR TITLE
Set the undercloud_ntp_server in the triple-o templates

### DIFF
--- a/profiles/main.yml
+++ b/profiles/main.yml
@@ -53,6 +53,9 @@ private_external_netmask: 255.255.255.0
 # Tripleo maps external network port to noop.yml, lets keep the default behavior
 allow_external_on_compute: false
 
+# Get the time server from the NTP_SERVER environment variable.
+ntp_server: "{{ lookup('env', 'NTP_SERVER')|default('0.pool.ntp.org', true) }}"
+
 # neutron dns:
 dns_server: 8.8.8.8
 

--- a/profiles/openshift-deploy.yml
+++ b/profiles/openshift-deploy.yml
@@ -92,6 +92,8 @@ vendor_id: 144d
 product_id: a804
 passthrough_type: type-PCI
 passthrough_hostname: "{{ lookup('env', 'PASSTHROUGH_HOSTNAME') }}"
+
+# Get the time server from the NTP_SERVER environment variable.
 ntp_server: "{{ lookup('env', 'NTP_SERVER') }}"
 
 # Metadata storage

--- a/roles/undercloud-prepare-host/templates/undercloud.11.conf.j2
+++ b/roles/undercloud-prepare-host/templates/undercloud.11.conf.j2
@@ -39,6 +39,9 @@
 # DNS nameserver(s) to use for the undercloud node. (list value)
 #undercloud_nameservers =
 
+# List of ntp servers to use. (list value)
+undercloud_ntp_servers = {{ ntp_server }}
+
 # Certificate file to use for OpenStack service SSL connections.
 # Setting this enables SSL for the OpenStack API endpoints, leaving it
 # unset disables SSL. (string value)

--- a/roles/undercloud-prepare-host/templates/undercloud.12.conf.j2
+++ b/roles/undercloud-prepare-host/templates/undercloud.12.conf.j2
@@ -37,7 +37,7 @@
 #undercloud_nameservers =
 
 # List of ntp servers to use. (list value)
-#undercloud_ntp_servers =
+undercloud_ntp_servers = {{ ntp_server }}
 
 # DNS domain name to use when deploying the overcloud. The overcloud
 # parameter "CloudDomain" must be set to a matching value. (string


### PR DESCRIPTION
Use the ansible variable ntp_server in when setting up the undercloud. The value is set in openshift-deploy.yml and is read from an environment variable.
