### PR TITLE
Use the redhat-performance repository in the requirements file.

### DIFF
--- a/requirements-openshift-build.txt
+++ b/requirements-openshift-build.txt
@@ -1,4 +1,4 @@
 git+https://github.com/openstack/browbeat.git#egg=browbeat
 git+https://github.com/openstack/tripleo-quickstart.git#egg=tripleo-quickstart
 git+https://github.com/openstack/tripleo-quickstart-extras.git#egg=tripleo-quickstart-extras
-git+https://github.com/jkilpatr/tripleo-quickstart-scalelab.git#egg=tripleo-quickstart-scalelab
+git+https://github.com/redhat-performance/tripleo-quickstart-scalelab.git#egg=tripleo-quickstart-scalelab


### PR DESCRIPTION
Having the old repository caused a problem with the last deployment where the cidr ranges were not updated. 