### PR TITLE
Disabling telemetry using roles_data-notelem.yaml.

### DIFF
--- a/roles/overcloud-deploy/templates/overcloud-deploy.sh.j2
+++ b/roles/overcloud-deploy/templates/overcloud-deploy.sh.j2
@@ -3,7 +3,7 @@ set -eux
 date
 source {{stackrc}}
 time openstack overcloud deploy --templates \
--r /home/stack/templates/roles_data.yaml \
+-r /home/stack/templates/roles_data-notelem.yaml \
 -e /home/stack/templates/scheduler-hints.yaml \
 -e /usr/share/openstack-tripleo-heat-templates/environments/network-isolation.yaml \
 -e /home/stack/templates/network-environment.yaml \
@@ -15,6 +15,5 @@ time openstack overcloud deploy --templates \
 -e /home/stack/templates/environments/compute-params.yaml \
 -e /home/stack/templates/environments/controller-params.yaml \
 -e /home/stack/templates/environments/firstboot-env.yaml \
--e /usr/share/openstack-tripleo-heat-templates/environments/disable-telemetry.yaml \
 -e deploy.yml &> /home/stack/overcloud-deploy.log
 date


### PR DESCRIPTION
Trying to disable telemetry by
openstack-tripleo-heat-templates/environments/disable-telemetry.yaml
did not work.  Use roles_data-notelem.yaml instead.

@mbruzek please merge once https://github.com/redhat-performance/openstack-templates/pull/19 is merged, thanks.