### PR TITLE
Change subnet_pool_start due to conflict with controller IPs.

### DIFF
--- a/profiles/openshift-deploy.yml
+++ b/profiles/openshift-deploy.yml
@@ -49,7 +49,7 @@ private_external_netmask: "{{ lookup('env', 'PRIVATE_EXTERNAL_NETMASK')|default(
 allow_external_on_compute: false
 
 # Public subnet settings:
-subnet_pool_start: "{{ lookup('env', 'SUBNET_POOL_START')|default('172.21.0.3', true) }}"
+subnet_pool_start: "{{ lookup('env', 'SUBNET_POOL_START')|default('172.21.0.100', true) }}"
 subnet_pool_end: "{{ lookup('env', 'SUBNET_POOL_END')|default('172.21.255.254', true) }}"
 subnet_gateway: "{{ lookup('env', 'SUBNET_GATEWAY')|default('172.21.0.1', true) }}"
 subnet_range: "{{ lookup('env', 'SUBNET_RANGE')|default('172.21.0.0/16', true) }}"


### PR DESCRIPTION
This PR is to start a discussion how the real problem can be fixed.  This PR only reverts the previous change to subnet_pool_start, which is very likely not a real solution.  There are conflicts between the FIP ranges and IPs allocated on the 3 controllers.  The controller conflicting IPs are are .8,  .10,  .13, but on the same network range as the FIP range. @mbruzek  PTAL