### PR TITLE
Changing the host_type based on a deploy error.

### DIFF
--- a/profiles/openshift-deploy.yml
+++ b/profiles/openshift-deploy.yml
@@ -70,14 +70,14 @@ total_hosts: 50
 
 openstack_deployment_hosts:
   - host_type:
-      pin: 1029pcompute # as mapped in roles data under HostnameFormatDefault will have -# appended to lock hosts to machines
+      pin: compute # as mapped in roles data under HostnameFormatDefault will have -# appended to lock hosts to machines
       title: P1029Compute # The actual title we use to deploy the role, the name field in roles data
-      hint: 1029p # The hint we look for in the management address string to determine what type of host we're looking at
+      hint: "1029p" # The hint we look for in the management address string to determine what type of host we're looking at
       count: 36 # number of hosts
   - host_type: #1029u's in the current template
       pin: cephstorage
       title: CephStorage
-      hint: 1029u
+      hint: "1029u"
       count: 5
 
 controller_type: 1029p


### PR DESCRIPTION
Browbeat does not have a host_type of 1029pcompute but has a template for compute:
https://github.com/openstack/browbeat/tree/master/ansible/install/roles/collectd-openstack/templates

This change must be related to a change in the openstack-templates repository with a similar name change.

Will the proper 1029p template/settings still be picked up after a change like this?