### PR TITLE
Disable notifications

### DIFF
--- a/roles/overcloud-deploy/templates/overcloud-deploy.sh.j2
+++ b/roles/overcloud-deploy/templates/overcloud-deploy.sh.j2
@@ -9,6 +9,7 @@ time openstack overcloud deploy --templates \
 -e /home/stack/templates/network-environment.yaml \
 -e /usr/share/openstack-tripleo-heat-templates/environments/puppet-pacemaker.yaml \
 -e /home/stack/templates/{{ceph_host}}-storage-environment.yaml \
+-e /home/stack/templates/disable-notifications.yaml \
 --libvirt-type=kvm \
 --ntp-server {{ntp_server}} \
 -e /home/stack/templates/environments/args.yaml \


### PR DESCRIPTION
This commit ensures that we pass the environmental file for disabling
notifications fro mthe various OpenStack services without which RabbitMQ
would be overwhelmed when telemetry is disabled.

Hence, when passing /home/stack/templates/roles_data-notelem.yaml we
also need to pass /home/stack/templates/disable-notifications.yaml to
the deploy command.