### PR TITLE
Making the staging script call the staging templates.

### DIFF
--- a/profiles/openshift-staging.yml
+++ b/profiles/openshift-staging.yml
@@ -42,17 +42,17 @@ external_network_vip: "{{ lookup('env', 'EXTERNAL_NETWORK_VIP') }}"
 # External private vlan on undercloud:
 public_net_device: eno1
 deploy_external_private_vlan: true
-external_vlan_device: enp94s0f1.10
+external_vlan_device: enp94s0f3.620
 private_external_address: "{{ lookup('env', 'PRIVATE_EXTERNAL_ADDRESS') }}"
-private_external_netmask: "{{ lookup('env', 'PRIVATE_EXTERNAL_NETMASK')|default('255.255.0.0', true) }}"
+private_external_netmask: "{{ lookup('env', 'PRIVATE_EXTERNAL_NETMASK')|default('255.255.255.192', true) }}"
 # Tripleo maps external network port to noop.yml, keep the default behavior
 allow_external_on_compute: false
 
 # Public subnet settings:
-subnet_pool_start: "{{ lookup('env', 'SUBNET_POOL_START')|default('172.21.0.100', true) }}"
-subnet_pool_end: "{{ lookup('env', 'SUBNET_POOL_END')|default('172.21.255.254', true) }}"
-subnet_gateway: "{{ lookup('env', 'SUBNET_GATEWAY')|default('172.21.0.1', true) }}"
-subnet_range: "{{ lookup('env', 'SUBNET_RANGE')|default('172.21.0.0/16', true) }}"
+subnet_pool_start: "{{ lookup('env', 'SUBNET_POOL_START')|default('10.12.95.200', true) }}"
+subnet_pool_end: "{{ lookup('env', 'SUBNET_POOL_END')|default('10.12.95.251', true) }}"
+subnet_gateway: "{{ lookup('env', 'SUBNET_GATEWAY')|default('10.12.95.193', true) }}"
+subnet_range: "{{ lookup('env', 'SUBNET_RANGE')|default('10.12.95.192/26', true) }}"
 
 # neutron dns:
 dns_server: "{{ lookup('env', 'DNS_SERVER') }}"


### PR DESCRIPTION
The staging environment needs different templates due to the networking difference and not having any 1029u machines.

This PR uses the new `openshift-scalelab-staging` templates.