### PR TITLE
Fixing the template path errors and gateway address.

### DIFF
--- a/profiles/openshift-staging.yml
+++ b/profiles/openshift-staging.yml
@@ -53,7 +53,7 @@ allow_external_on_compute: false
 # Public subnet settings:
 subnet_pool_start: "{{ lookup('env', 'SUBNET_POOL_START')|default('10.12.95.200', true) }}"
 subnet_pool_end: "{{ lookup('env', 'SUBNET_POOL_END')|default('10.12.95.251', true) }}"
-subnet_gateway: "{{ lookup('env', 'SUBNET_GATEWAY')|default('10.12.95.193', true) }}"
+subnet_gateway: "{{ lookup('env', 'SUBNET_GATEWAY')|default('10.12.95.254', true) }}"
 subnet_range: "{{ lookup('env', 'SUBNET_RANGE')|default('10.12.95.192/26', true) }}"
 
 # neutron dns:
@@ -87,7 +87,7 @@ num_controllers: 3
 
 ceph_host: 1029p
 templates_repo: "{{ lookup('env', 'TEMPLATE_REPOSITORY') }}"
-templates_repo_path: "{{ lookup('env', 'TEMPLATE_REPOSITORY_PATH')|default('RDU-Scale/Ocata/openshift-scalelab-ci/', true) }}"
+templates_repo_path: "{{ lookup('env', 'TEMPLATE_REPOSITORY_PATH')|default('RDU-Scale/Ocata/openshift-scalelab-staging/', true) }}"
 ansible_ssh_pass: "{{ lookup('env', 'ANSIBLE_SSH_PASS') }}"
 
 alias: nvme

--- a/roles/overcloud-prepare-templates/tasks/main.yml
+++ b/roles/overcloud-prepare-templates/tasks/main.yml
@@ -4,12 +4,12 @@
 - name: Clone the templates repo
   local_action:
     module: git
-    repo: "{{templates_repo}}"
-    dest: "lookup('env','WORKSPACE')/templates/"
+    repo: "{{ templates_repo }}"
+    dest: "{{ playbook_dir }}/templates/"
 
 - name: Copy over folder for this deployment
   copy:
-    src: "lookup('env','WORKSPACE')/templates/{{templates_repo_path}}"
+    src: "{{ playbook_dir }}/templates/{{ templates_repo_path }}"
     dest: "/home/stack/templates"
     owner: stack
     group: stack


### PR DESCRIPTION
While reviewing the log of the latest deploy: https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/scale-ci_install_staging_OpenStack/2/consoleFull

I found an unusual path in a task:
```
TASK [overcloud-prepare-templates : Copy over folder for this deployment] ******
task path: /home/slave5/workspace/scale-ci_install_staging_OpenStack/venv/usr/local/share/ansible/roles/overcloud-prepare-templates/tasks/main.yml:10
Thursday 05 April 2018  17:11:58 -0400 (0:00:00.757)       1:08:06.035 ******** 
changed: [b04-h02-1029p.rdu.openstack.engineering.redhat.com] => {"changed": true, "dest": "/home/stack/templates/", "src": "/home/slave5/workspace/scale-ci_install_staging_OpenStack/venv/playbooks/lookup('env','WORKSPACE')/templates/RDU-Scale/Ocata/openshift-scalelab-ci/"}
```
Can not use `lookup('env','WORKSPACE')` inside a variable name, it does not resolve to the workspace it is interpreted literally.

Also use a gateway that is outside the external allocation and use the staging templates that were created.