### PR TITLE
Making the NAT process optional.

### DIFF
--- a/profiles/openshift-deploy.yml
+++ b/profiles/openshift-deploy.yml
@@ -41,7 +41,11 @@ external_network_vip: "{{ lookup('env', 'EXTERNAL_NETWORK_VIP') }}"
 
 # External private vlan on undercloud:
 public_net_device: eno1
+# Deploy a vlan device for the external private network.
 deploy_external_private_vlan: true
+# Use Network Address Translation (NAT) to route the traffic to this device.
+deploy_external_private_nat: true
+# The external vlan device name.
 external_vlan_device: enp94s0f1.10
 private_external_address: "{{ lookup('env', 'PRIVATE_EXTERNAL_ADDRESS') }}"
 private_external_netmask: "{{ lookup('env', 'PRIVATE_EXTERNAL_NETMASK')|default('255.255.0.0', true) }}"

--- a/profiles/openshift-staging.yml
+++ b/profiles/openshift-staging.yml
@@ -41,8 +41,11 @@ external_network_vip: "{{ lookup('env', 'EXTERNAL_NETWORK_VIP') }}"
 
 # External private vlan on undercloud:
 public_net_device: eno1
+# Deploy a vlan device for the external private network.
 deploy_external_private_vlan: true
-
+# Do not use Network Address Translation (NAT) to route the traffic to this device.
+deploy_external_private_nat: false
+# The external vlan device name.
 external_vlan_device: enp94s0f3.620
 private_external_address: "{{ lookup('env', 'PRIVATE_EXTERNAL_ADDRESS') }}"
 private_external_netmask: "{{ lookup('env', 'PRIVATE_EXTERNAL_NETMASK')|default('255.255.255.192', true) }}"

--- a/roles/undercloud-prepare-host/tasks/main.yml
+++ b/roles/undercloud-prepare-host/tasks/main.yml
@@ -117,14 +117,14 @@
      iptables -t nat -A POSTROUTING -o {{public_net_device}} -j MASQUERADE \n
      iptables -A FORWARD -i {{public_net_device}} -o {{external_vlan_device}} -m state --state RELATED,ESTABLISHED -j ACCEPT \n
      iptables -A FORWARD -i {{external_vlan_device}} -o {{public_net_device}} -j ACCEPT"
-  when: deploy_external_private_vlan
+  when: deploy_external_private_vlan and deploy_external_private_nat
 
 - name: Make sure iptables-services is installed
   yum:
     name: iptables-services
     state: present
-  when: deploy_external_private_vlan
+  when: deploy_external_private_vlan and deploy_external_private_nat
 
 - name: Save iptables
   shell: service iptables save
-  when: deploy_external_private_vlan
+  when: deploy_external_private_vlan and deploy_external_private_nat


### PR DESCRIPTION
With the new network environment in the staging area, it is no longer necessary to configure NAT to the external network, but it is still needed for the "normal" scale-ci environment at this time. Making it optional and configured by a variable.