### PR TITLE
Making the script return 1 when an error occurred.

### DIFF
--- a/roles/rebuild-undercloud/templates/toggle-rebuild.sh.j2
+++ b/roles/rebuild-undercloud/templates/toggle-rebuild.sh.j2
@@ -1,13 +1,23 @@
-#! /bin/sh
-#
+#!/bin/bash
+# This script tells foreman to rebuild the host.
 
-USER="{{cloud_title}}" 
-PASS="{{ticket_number}}" 
-FOREMAN_URL="{{foreman_url}}" 
+USER="{{cloud_title}}"
+PASS="{{ticket_number}}"
+FOREMAN_URL="{{foreman_url}}"
 NAME="{{undercloud_hostname}}"
 
-curl -H 'Content-Type: application/json' \
-     -k -X PUT \
+RESPONSE=$(curl --silent --show-error --insecure \
+     -H 'Content-Type: application/json' \
+     -X PUT \
      -u $USER:$PASS \
      -d '{"host": {"build": "1"}}' \
-     $FOREMAN_URL/api/hosts/$NAME
+     $FOREMAN_URL/api/hosts/$NAME)
+
+echo $RESPONSE
+
+# Check the response for the error key and exit this script appropriately.
+if [[ $RESPONSE == *"error"* ]]; then
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
In staging we encountered a problem with this toggle-rebuild.sh script because `curl` does not return an error when HTTP authentication fails. This turned out to be a critical error and should have stopped the install process because jobs after that failed. 

Updating the script to return 1 when an error occurred.
