### PR TITLE
Ansible 2.3 lineinfile does not recognize path parameter

### DIFF
--- a/roles/undercloud-install/tasks/main.yml
+++ b/roles/undercloud-install/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: OSP11/Ocata - Tune Keystone processes to 24
   become: true
   lineinfile:
-    path: "{{item}}"
+    dest: "{{item}}"
     state: present
     regexp: '^([\t\s]*WSGIDaemonProcess.*)processes=[0-9]+ threads=[0-9]+(.*)$'
     line: '\1processes=24 threads=6\2'


### PR DESCRIPTION
Path is introduced in Ansible 2.4, but the job uses Ansible 2.3