### PR TITLE
Expanding ctlplane ip address ranges

### DIFF
--- a/roles/undercloud-prepare-host/templates/undercloud.10.conf.j2
+++ b/roles/undercloud-prepare-host/templates/undercloud.10.conf.j2
@@ -22,11 +22,13 @@
 # defined by local_interface, with the netmask defined by the prefix
 # portion of the value. (string value)
 #local_ip = 192.0.2.1/24
+local_ip = 192.168.0.1/16
 
 # Network gateway for the Neutron-managed network for Overcloud
 # instances. This should match the local_ip above when using
 # masquerading. (string value)
 #network_gateway = 192.0.2.1
+network_gateway = 192.168.0.1
 
 # Virtual IP address to use for the public endpoints of Undercloud
 # services.  Only used if undercloud_service_certficate is set.
@@ -84,6 +86,7 @@ local_interface = {{local_interface}}
 # all other network options related to the CIDR (e.g. local_ip) must
 # also be set to maintain a valid configuration. (string value)
 #network_cidr = 192.0.2.0/24
+network_cidr = 192.168.0.0/16
 
 # Network that will be masqueraded for external access, if required.
 # This should be the subnet used for PXE booting. (string value)
@@ -91,11 +94,13 @@ local_interface = {{local_interface}}
 
 # Start of DHCP allocation range for PXE and DHCP of Overcloud
 # instances. (string value)
-dhcp_start = 192.0.2.51
+#dhcp_start = 192.0.2.5
+dhcp_start = 192.168.10.1
 
 # End of DHCP allocation range for PXE and DHCP of Overcloud
 # instances. (string value)
-dhcp_end = 192.0.2.250
+#dhcp_end = 192.0.2.24
+dhcp_end = 192.168.19.250
 
 # Path to hieradata override file. If set, the file will be copied
 # under /etc/puppet/hieradata and set as the first file in the hiera
@@ -119,7 +124,7 @@ dhcp_end = 192.0.2.250
 # process.  Should not overlap with the range defined by dhcp_start
 # and dhcp_end, but should be in the same network. (string value)
 # Deprecated group/name - [DEFAULT]/discovery_iprange
-inspection_iprange = 192.0.2.5,192.0.2.50
+inspection_iprange = 192.168.1.1,192.168.9.250
 
 # Whether to enable extra hardware collection during the inspection
 # process. Requires python-hardware or python-hardware-detect package

--- a/roles/undercloud-prepare-host/templates/undercloud.11.conf.j2
+++ b/roles/undercloud-prepare-host/templates/undercloud.11.conf.j2
@@ -22,11 +22,13 @@
 # defined by local_interface, with the netmask defined by the prefix
 # portion of the value. (string value)
 #local_ip = 192.168.24.1/24
+local_ip = 192.168.0.1/16
 
 # Network gateway for the Neutron-managed network for Overcloud
 # instances. This should match the local_ip above when using
 # masquerading. (string value)
 #network_gateway = 192.168.24.1
+network_gateway = 192.168.0.1
 
 # Virtual IP address to use for the public endpoints of Undercloud
 # services. Only used with SSL. (string value)
@@ -80,6 +82,7 @@ local_interface = {{local_interface}}
 # instances. This should be the subnet used for PXE booting. (string
 # value)
 #network_cidr = 192.168.24.0/24
+network_cidr = 192.168.0.0/16
 
 # Network that will be masqueraded for external access, if required.
 # This should be the subnet used for PXE booting. (string value)
@@ -87,11 +90,13 @@ local_interface = {{local_interface}}
 
 # Start of DHCP allocation range for PXE and DHCP of Overcloud
 # instances. (string value)
-dhcp_start = 192.168.24.51
+#dhcp_start = 192.168.24.5
+dhcp_start = 192.168.10.1
 
 # End of DHCP allocation range for PXE and DHCP of Overcloud
 # instances. (string value)
-dhcp_end = 192.168.24.250
+#dhcp_end = 192.168.24.24
+dhcp_end = 192.168.19.250
 
 # Path to hieradata override file. If set, the file will be copied
 # under /etc/puppet/hieradata and set as the first file in the hiera
@@ -115,7 +120,8 @@ dhcp_end = 192.168.24.250
 # process.  Should not overlap with the range defined by dhcp_start
 # and dhcp_end, but should be in the same network. (string value)
 # Deprecated group/name - [DEFAULT]/discovery_iprange
-inspection_iprange = 192.168.24.5,192.168.24.50
+#inspection_iprange = 192.168.24.100,192.168.24.120
+inspection_iprange = 192.168.1.1,192.168.9.250
 
 # Whether to enable extra hardware collection during the inspection
 # process. Requires python-hardware or python-hardware-detect package

--- a/roles/undercloud-prepare-host/templates/undercloud.12.conf.j2
+++ b/roles/undercloud-prepare-host/templates/undercloud.12.conf.j2
@@ -17,11 +17,13 @@
 # defined by local_interface, with the netmask defined by the prefix
 # portion of the value. (string value)
 #local_ip = 192.168.24.1/24
+local_ip = 192.168.0.1/16
 
 # Network gateway for the Neutron-managed network for Overcloud
 # instances. This should match the local_ip above when using
 # masquerading. (string value)
 #network_gateway = 192.168.24.1
+network_gateway = 192.168.0.1
 
 # Virtual IP or DNS address to use for the public endpoints of
 # Undercloud services. Only used with SSL. (string value)
@@ -83,6 +85,7 @@ local_interface = {{local_interface}}
 # instances. This should be the subnet used for PXE booting. (string
 # value)
 #network_cidr = 192.168.24.0/24
+network_cidr = 192.168.0.0/16
 
 # Network that will be masqueraded for external access, if required.
 # This should be the subnet used for PXE booting. (string value)
@@ -90,11 +93,13 @@ local_interface = {{local_interface}}
 
 # Start of DHCP allocation range for PXE and DHCP of Overcloud
 # instances. (string value)
-dhcp_start = 192.168.24.51
+#dhcp_start = 192.168.24.5
+dhcp_start = 192.168.10.1
 
 # End of DHCP allocation range for PXE and DHCP of Overcloud
 # instances. (string value)
-dhcp_end = 192.168.24.250
+#dhcp_end = 192.168.24.24
+dhcp_end = 192.168.19.250
 
 # Path to hieradata override file. If set, the file will be copied
 # under /etc/puppet/hieradata and set as the first file in the hiera
@@ -118,7 +123,8 @@ dhcp_end = 192.168.24.250
 # process.  Should not overlap with the range defined by dhcp_start
 # and dhcp_end, but should be in the same network. (string value)
 # Deprecated group/name - [DEFAULT]/discovery_iprange
-inspection_iprange = 192.168.24.5,192.168.24.50
+#inspection_iprange = 192.168.24.100,192.168.24.120
+inspection_iprange = 192.168.1.1,192.168.9.250
 
 # Whether to enable extra hardware collection during the inspection
 # process. Requires python-hardware or python-hardware-detect package

--- a/roles/undercloud-prepare-host/templates/undercloud.13.conf.j2
+++ b/roles/undercloud-prepare-host/templates/undercloud.13.conf.j2
@@ -16,6 +16,7 @@
 # portion of the value will be assigned to the network interface
 # defined by local_interface, with the netmask defined by the prefix
 # portion of the value. (string value)
+#local_ip = 192.168.24.1/24
 local_ip = 192.168.0.1/16
 
 # Virtual IP or DNS address to use for the public endpoints of


### PR DESCRIPTION
This expands 10,11,12 OpenStack ctlplane Ip Address ranges for both the
introspection address pool and the overcloud DHCP/PXE pool.  Expanding
these pools will ensure we have plenty of address space as the scale of
the overcloud may increase in the future or if qnq-1 based clouds consume
more ctlplane addresses.

Commented out defaults are included to show difference between defaults and
adjusted values.  OSP 13 undercloud.conf already has a /16 configured.