### PR TITLE
Clean up the 1029p and 1029u nic-configs

### DIFF
--- a/roles/overcloud-prepare-templates/files/nic-configs/1029p-cephstorage.yaml
+++ b/roles/overcloud-prepare-templates/files/nic-configs/1029p-cephstorage.yaml
@@ -2,7 +2,7 @@ heat_template_version: 2015-04-30
 
 description: >
   Software Config to drive os-net-config to configure VLANs for the
-  storage role.
+  ceph storage role.
 
 parameters:
   ControlPlaneIp:
@@ -33,29 +33,17 @@ parameters:
     default: ''
     description: IP address/subnet on the management network
     type: string
-  ExternalNetworkVlanID:
-    default: 10
-    description: Vlan ID for the internal_api network traffic.
-    type: number
-  InternalApiNetworkVlanID:
-    default: 20
-    description: Vlan ID for the internal_api network traffic.
-    type: number
   StorageNetworkVlanID:
     default: 30
     description: Vlan ID for the storage network traffic.
     type: number
-  TenantNetworkVlanID:
-    default: 50
-    description: Vlan ID for the tenant network traffic.
+  StorageMgmtNetworkVlanID:
+    default: 40
+    description: Vlan ID for the storage mgmt network traffic.
     type: number
   ManagementNetworkVlanID:
     default: 60
     description: Vlan ID for the management network traffic.
-    type: number
-  StorageMgmtNetworkVlanID:
-    default: 70
-    description: Vlan ID for the storage management network traffic.
     type: number
   ControlPlaneSubnetCidr: # Override this via parameter_defaults
     default: '24'
@@ -89,47 +77,8 @@ resources:
         os_net_config:
           network_config:
             -
-              type: interface
-              name: eno1
-              use_dhcp: true
-              primary: true
-            -
               type: ovs_bridge
-              name: br-storage
-              members:
-                -
-                  type: interface
-                  name: enp94s0f0
-                  primary: true
-                -
-                  type: vlan
-                  vlan_id: {get_param: StorageNetworkVlanID}
-                  addresses:
-                    -
-                      ip_netmask: {get_param: StorageIpSubnet}
-                -
-                  type: vlan
-                  vlan_id: {get_param: StorageMgmtNetworkVlanID}
-                  addresses:
-                    -
-                      ip_netmask: {get_param: StorageMgmtIpSubnet}
-            -
-              type: ovs_bridge
-              name: br-tenant
-              members:
-                -
-                  type: interface
-                  name: enp94s0f2
-                  primary: true
-                -
-                  type: vlan
-                  vlan_id: {get_param: TenantNetworkVlanID}
-                  addresses:
-                    -
-                      ip_netmask: {get_param: TenantIpSubnet}
-            -
-              type: ovs_bridge
-              name: br-ctl
+              name: br-ex
               use_dhcp: false
               dns_servers: {get_param: DnsServers}
               addresses:
@@ -143,22 +92,39 @@ resources:
                 -
                   ip_netmask: 169.254.169.254/32
                   next_hop: {get_param: EC2MetadataIp}
-                -
-                  default: true
-                  next_hop: {get_param: ControlPlaneDefaultRoute}
               members:
                 -
                   type: interface
                   name: enp94s0f1
                   primary: true
+            -
+              type: ovs_bridge
+              name: br-storage
+              members:
+                -
+                  type: interface
+                  name: enp94s0f2
+                  primary: true
                 -
                   type: vlan
-                  vlan_id: {get_param: InternalApiNetworkVlanID}
+                  vlan_id: {get_param: StorageNetworkVlanID}
                   addresses:
                     -
-                      ip_netmask: {get_param: InternalApiIpSubnet}
-
-
+                      ip_netmask: {get_param: StorageIpSubnet}
+            -
+              type: ovs_bridge
+              name: br-storagemgmt
+              members:
+                -
+                  type: interface
+                  name: enp94s0f3
+                  primary: true
+                -
+                  type: vlan
+                  vlan_id: {get_param: StorageMgmtNetworkVlanID}
+                  addresses:
+                    -
+                      ip_netmask: {get_param: StorageMgmtIpSubnet}
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/roles/overcloud-prepare-templates/files/nic-configs/1029p-compute.yaml
+++ b/roles/overcloud-prepare-templates/files/nic-configs/1029p-compute.yaml
@@ -81,24 +81,32 @@ resources:
         os_net_config:
           network_config:
             -
-              type: interface
-              name: eno1
-              use_dhcp: true
-              primary: true
-            -
               type: ovs_bridge
-              name: br-storage
+              name: br-ex
+              use_dhcp: false
+              dns_servers: {get_param: DnsServers}
+              addresses:
+                -
+                  ip_netmask:
+                    list_join:
+                      - '/'
+                      - - {get_param: ControlPlaneIp}
+                        - {get_param: ControlPlaneSubnetCidr}
+              routes:
+                -
+                  ip_netmask: 169.254.169.254/32
+                  next_hop: {get_param: EC2MetadataIp}
               members:
                 -
                   type: interface
-                  name: enp94s0f2
+                  name: enp94s0f1
                   primary: true
                 -
                   type: vlan
-                  vlan_id: {get_param: StorageNetworkVlanID}
+                  vlan_id: {get_param: InternalApiNetworkVlanID}
                   addresses:
                     -
-                      ip_netmask: {get_param: StorageIpSubnet}
+                      ip_netmask: {get_param: InternalApiIpSubnet}
             -
               type: ovs_bridge
               name: br-tenant
@@ -115,44 +123,18 @@ resources:
                       ip_netmask: {get_param: TenantIpSubnet}
             -
               type: ovs_bridge
-              name: br-ex
-              use_dhcp: false
-              dns_servers: {get_param: DnsServers}
-              addresses:
-                -
-                  ip_netmask:
-                    list_join:
-                      - '/'
-                      - - {get_param: ControlPlaneIp}
-                        - {get_param: ControlPlaneSubnetCidr}
-              routes:
-                -
-                  ip_netmask: 169.254.169.254/32
-                  next_hop: {get_param: EC2MetadataIp}
-                -
-                  default: true
-                  next_hop: {get_param: ControlPlaneDefaultRoute}
+              name: br-storage
               members:
                 -
                   type: interface
-                  name: enp94s0f1
-                  primary: true
-
-            -
-              type: ovs_bridge
-              name: br-api
-              members:
-                -
-                  type: interface
-                  name: enp94s0f3
+                  name: enp94s0f2
                   primary: true
                 -
                   type: vlan
-                  vlan_id: {get_param: InternalApiNetworkVlanID}
+                  vlan_id: {get_param: StorageNetworkVlanID}
                   addresses:
                     -
-                      ip_netmask: {get_param: InternalApiIpSubnet}
-
+                      ip_netmask: {get_param: StorageIpSubnet}
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/roles/overcloud-prepare-templates/files/nic-configs/1029p-controller.yaml
+++ b/roles/overcloud-prepare-templates/files/nic-configs/1029p-controller.yaml
@@ -2,7 +2,7 @@ heat_template_version: 2015-04-30
 
 description: >
   Software Config to drive os-net-config to configure VLANs for the
-  compute role.
+  controller role.
 
 parameters:
   ControlPlaneIp:
@@ -33,9 +33,14 @@ parameters:
     default: ''
     description: IP address/subnet on the management network
     type: string
+  BondInterfaceOvsOptions:
+    default: 'bond_mode=active-backup'
+    description: The ovs_options string for the bond interface. Set things like
+                 lacp=active and/or bond_mode=balance-slb using this option.
+    type: string
   ExternalNetworkVlanID:
     default: 10
-    description: Vlan ID for the internal_api network traffic.
+    description: Vlan ID for the external network traffic.
     type: number
   InternalApiNetworkVlanID:
     default: 20
@@ -45,6 +50,10 @@ parameters:
     default: 30
     description: Vlan ID for the storage network traffic.
     type: number
+  StorageMgmtNetworkVlanID:
+    default: 40
+    description: Vlan ID for the storage mgmt network traffic.
+    type: number
   TenantNetworkVlanID:
     default: 50
     description: Vlan ID for the tenant network traffic.
@@ -53,24 +62,13 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  StorageMgmtNetworkVlanID:
-    default: 70
-    description: Vlan ID for the storage management network traffic.
-    type: number
+  ExternalInterfaceDefaultRoute:
+    default: '10.0.0.1'
+    description: default route for the external network
+    type: string
   ControlPlaneSubnetCidr: # Override this via parameter_defaults
     default: '24'
     description: The subnet CIDR of the control plane network.
-    type: string
-  ControlPlaneDefaultRoute: # Override this via parameter_defaults
-    description: The default route of the control plane network.
-    type: string
-  ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: '10.0.0.1'
-    description: The default route of the external network.
-    type: string
-  ManagementInterfaceDefaultRoute: # Commented out by default in this template
-    default: unset
-    description: The default route of the management network.
     type: string
   DnsServers: # Override this via parameter_defaults
     default: []
@@ -89,41 +87,8 @@ resources:
         os_net_config:
           network_config:
             -
-              type: interface
-              name: eno1
-              use_dhcp: true
-              primary: true
-            -
               type: ovs_bridge
-              name: br-storage
-              members:
-                -
-                  type: interface
-                  name: enp94s0f2
-                  primary: true
-                -
-                  type: vlan
-                  vlan_id: {get_param: StorageNetworkVlanID}
-                  addresses:
-                    -
-                      ip_netmask: {get_param: StorageIpSubnet}
-            -
-              type: ovs_bridge
-              name: br-tenant
-              members:
-                -
-                  type: interface
-                  name: enp94s0f0
-                  primary: true
-                -
-                  type: vlan
-                  vlan_id: {get_param: TenantNetworkVlanID}
-                  addresses:
-                    -
-                      ip_netmask: {get_param: TenantIpSubnet}
-            -
-              type: ovs_bridge
-              name: {get_input: bridge_name}
+              name: br-ex
               use_dhcp: false
               dns_servers: {get_param: DnsServers}
               addresses:
@@ -137,9 +102,6 @@ resources:
                 -
                   ip_netmask: 169.254.169.254/32
                   next_hop: {get_param: EC2MetadataIp}
-                -
-                  default: true
-                  next_hop: {get_param: ControlPlaneDefaultRoute}
               members:
                 -
                   type: interface
@@ -157,7 +119,34 @@ resources:
                   addresses:
                     -
                       ip_netmask: {get_param: InternalApiIpSubnet}
-
+            -
+              type: ovs_bridge
+              name: br-tenant
+              members:
+                -
+                  type: interface
+                  name: enp94s0f0
+                  primary: true
+                -
+                  type: vlan
+                  vlan_id: {get_param: TenantNetworkVlanID}
+                  addresses:
+                    -
+                      ip_netmask: {get_param: TenantIpSubnet}
+            -
+              type: ovs_bridge
+              name: br-storage
+              members:
+                -
+                  type: interface
+                  name: enp94s0f2
+                  primary: true
+                -
+                  type: vlan
+                  vlan_id: {get_param: StorageNetworkVlanID}
+                  addresses:
+                    -
+                      ip_netmask: {get_param: StorageIpSubnet}
             -
               type: ovs_bridge
               name: br-storagemgmt
@@ -172,8 +161,6 @@ resources:
                   addresses:
                     -
                       ip_netmask: {get_param: StorageMgmtIpSubnet}
-
-
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/roles/overcloud-prepare-templates/files/nic-configs/1029u-cephstorage.yaml
+++ b/roles/overcloud-prepare-templates/files/nic-configs/1029u-cephstorage.yaml
@@ -2,7 +2,7 @@ heat_template_version: 2015-04-30
 
 description: >
   Software Config to drive os-net-config to configure VLANs for the
-  compute role.
+  ceph storage role.
 
 parameters:
   ControlPlaneIp:
@@ -33,29 +33,17 @@ parameters:
     default: ''
     description: IP address/subnet on the management network
     type: string
-  ExternalNetworkVlanID:
-    default: 10
-    description: Vlan ID for the internal_api network traffic.
-    type: number
-  InternalApiNetworkVlanID:
-    default: 20
-    description: Vlan ID for the internal_api network traffic.
-    type: number
   StorageNetworkVlanID:
     default: 30
     description: Vlan ID for the storage network traffic.
     type: number
-  TenantNetworkVlanID:
-    default: 50
-    description: Vlan ID for the tenant network traffic.
+  StorageMgmtNetworkVlanID:
+    default: 40
+    description: Vlan ID for the storage mgmt network traffic.
     type: number
   ManagementNetworkVlanID:
     default: 60
     description: Vlan ID for the management network traffic.
-    type: number
-  StorageMgmtNetworkVlanID:
-    default: 70
-    description: Vlan ID for the storage management network traffic.
     type: number
   ControlPlaneSubnetCidr: # Override this via parameter_defaults
     default: '24'
@@ -89,10 +77,26 @@ resources:
         os_net_config:
           network_config:
             -
-              type: interface
-              name: eno1
-              use_dhcp: true
-              primary: true
+              type: ovs_bridge
+              name: br-ex
+              use_dhcp: false
+              dns_servers: {get_param: DnsServers}
+              addresses:
+                -
+                  ip_netmask:
+                    list_join:
+                      - '/'
+                      - - {get_param: ControlPlaneIp}
+                        - {get_param: ControlPlaneSubnetCidr}
+              routes:
+                -
+                  ip_netmask: 169.254.169.254/32
+                  next_hop: {get_param: EC2MetadataIp}
+              members:
+                -
+                  type: interface
+                  name: enp175s0f1
+                  primary: true
             -
               type: ovs_bridge
               name: br-storage
@@ -109,52 +113,7 @@ resources:
                       ip_netmask: {get_param: StorageIpSubnet}
             -
               type: ovs_bridge
-              name: br-tenant
-              members:
-                -
-                  type: interface
-                  name: enp175s0f0
-                  primary: true
-                -
-                  type: vlan
-                  vlan_id: {get_param: TenantNetworkVlanID}
-                  addresses:
-                    -
-                      ip_netmask: {get_param: TenantIpSubnet}
-            -
-              type: ovs_bridge
-              name: br-ex
-              use_dhcp: false
-              dns_servers: {get_param: DnsServers}
-              addresses:
-                -
-                  ip_netmask:
-                    list_join:
-                      - '/'
-                      - - {get_param: ControlPlaneIp}
-                        - {get_param: ControlPlaneSubnetCidr}
-              routes:
-                -
-                  ip_netmask: 169.254.169.254/32
-                  next_hop: {get_param: EC2MetadataIp}
-                -
-                  default: true
-                  next_hop: {get_param: ControlPlaneDefaultRoute}
-              members:
-                -
-                  type: interface
-                  name: enp175s0f1
-                  primary: true
-                -
-                  type: vlan
-                  vlan_id: {get_param: InternalApiNetworkVlanID}
-                  addresses:
-                    -
-                      ip_netmask: {get_param: InternalApiIpSubnet}
-
-            -
-              type: ovs_bridge
-              name: br-management
+              name: br-storagemgmt
               members:
                 -
                   type: interface
@@ -166,8 +125,6 @@ resources:
                   addresses:
                     -
                       ip_netmask: {get_param: StorageMgmtIpSubnet}
-
-
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.


### PR DESCRIPTION
I found a few extras left over in the nic-config files that I cleaned up.  Also
these config files should work with both qnq0 and qnq1 lab switch configs.