### PR TITLE
Remove unused vars, fix stack user password, undercloud.conf adjustments

### DIFF
--- a/profiles/main.yml
+++ b/profiles/main.yml
@@ -17,9 +17,6 @@ introspection: true
 # better introspection, be sure to turn bulk off if you use this
 introspect_with_retry: false
 
-# Dump version file to this directory
-version_directory: /etc
-
 # Stack user password:
 # Make a new password:
 # python -c "from passlib.hash import sha512_crypt; print sha512_crypt.encrypt('password')"

--- a/profiles/openshift-deploy.yml
+++ b/profiles/openshift-deploy.yml
@@ -17,9 +17,6 @@ introspection: false
 # better introspection, be sure to turn bulk off if you use this
 introspect_with_retry: true
 
-# Dump version file to this directory
-version_directory: /etc
-
 # Stack user password. Encrypted with sha512
 stack_password: "{{ lookup('env', 'STACK_PASSWORD') }}"
 
@@ -86,13 +83,6 @@ ceph_host: 1029u
 local_templates: false
 templates_repo: "{{ lookup('env', 'TEMPLATE_REPOSITORY') }}"
 templates_repo_path: "{{ lookup('env', 'TEMPLATE_REPOSITORY_PATH')|default('RDU-Scale/Ocata/openshift-scalelab-ci/', true) }}"
-ansible_ssh_pass: "{{ lookup('env', 'ANSIBLE_SSH_PASS') }}"
-
-alias: nvme
-vendor_id: 144d
-product_id: a804
-passthrough_type: type-PCI
-passthrough_hostname: "{{ lookup('env', 'PASSTHROUGH_HOSTNAME') }}"
 
 # Get the time server from the NTP_SERVER environment variable.
 ntp_server: "{{ lookup('env', 'NTP_SERVER') }}"
@@ -101,7 +91,3 @@ ntp_server: "{{ lookup('env', 'NTP_SERVER') }}"
 graphite_host: "{{ lookup('env', 'GRAPHITE') }}"
 # Graphite prefix / Cloud name used both with graphite and grafana dashboards
 graphite_prefix: "{{ lookup('env', 'CLOUD_NAME') }}"
-rsyslog_elasticsearch_server: "{{es_ip}}"
-rsyslog_aggregator_server: "{{es_ip}}"
-rsyslog_cloud_name: "{{graphite_prefix}}"
-es_ip: "{{ lookup('env', 'ES') }}"

--- a/profiles/openshift-small.yml
+++ b/profiles/openshift-small.yml
@@ -17,9 +17,6 @@ introspection: false
 # better introspection, be sure to turn bulk off if you use this
 introspect_with_retry: true
 
-# Dump version file to this directory
-version_directory: /etc
-
 # Stack user password. Encrypted with sha512
 stack_password: "{{ lookup('env', 'STACK_PASSWORD') }}"
 
@@ -88,13 +85,6 @@ ceph_host: 1029p  # There are no 1029u systems for the cloud07 environment.
 local_templates: true
 templates_repo: "{{ lookup('env', 'TEMPLATE_REPOSITORY') }}"
 templates_repo_path: "{{ lookup('env', 'TEMPLATE_REPOSITORY_PATH')|default('RDU-Scale/Ocata/openshift-scalelab-small/', true) }}"
-ansible_ssh_pass: "{{ lookup('env', 'ANSIBLE_SSH_PASS') }}"
-
-alias: nvme
-vendor_id: 144d
-product_id: a804
-passthrough_type: type-PCI
-passthrough_hostname: "{{ lookup('env', 'PASSTHROUGH_HOSTNAME') }}"
 
 # Get the time server from the NTP_SERVER environment variable.
 ntp_server: "{{ lookup('env', 'NTP_SERVER') }}"
@@ -103,7 +93,3 @@ ntp_server: "{{ lookup('env', 'NTP_SERVER') }}"
 graphite_host: "{{ lookup('env', 'GRAPHITE') }}"
 # Graphite prefix / Cloud name used both with graphite and grafana dashboards
 graphite_prefix: "{{ lookup('env', 'CLOUD_NAME') }}"
-rsyslog_elasticsearch_server: "{{es_ip}}"
-rsyslog_aggregator_server: "{{es_ip}}"
-rsyslog_cloud_name: "{{graphite_prefix}}"
-es_ip: "{{ lookup('env', 'ES') }}"

--- a/profiles/openshift-staging.yml
+++ b/profiles/openshift-staging.yml
@@ -17,9 +17,6 @@ introspection: false
 # better introspection, be sure to turn bulk off if you use this
 introspect_with_retry: true
 
-# Dump version file to this directory
-version_directory: /etc
-
 # Stack user password. Encrypted with sha512
 stack_password: "{{ lookup('env', 'STACK_PASSWORD') }}"
 
@@ -87,13 +84,6 @@ ceph_host: 1029p  # There are no 1029u systems for the cloud05 environment.
 local_templates: true
 templates_repo: "{{ lookup('env', 'TEMPLATE_REPOSITORY') }}"
 templates_repo_path: "{{ lookup('env', 'TEMPLATE_REPOSITORY_PATH')|default('RDU-Scale/Ocata/openshift-scalelab-staging/', true) }}"
-ansible_ssh_pass: "{{ lookup('env', 'ANSIBLE_SSH_PASS') }}"
-
-alias: nvme
-vendor_id: 144d
-product_id: a804
-passthrough_type: type-PCI
-passthrough_hostname: "{{ lookup('env', 'PASSTHROUGH_HOSTNAME') }}"
 
 # Get the time server from the NTP_SERVER environment variable.
 ntp_server: "{{ lookup('env', 'NTP_SERVER') }}"
@@ -102,7 +92,3 @@ ntp_server: "{{ lookup('env', 'NTP_SERVER') }}"
 graphite_host: "{{ lookup('env', 'GRAPHITE') }}"
 # Graphite prefix / Cloud name used both with graphite and grafana dashboards
 graphite_prefix: "{{ lookup('env', 'CLOUD_NAME') }}"
-rsyslog_elasticsearch_server: "{{es_ip}}"
-rsyslog_aggregator_server: "{{es_ip}}"
-rsyslog_cloud_name: "{{graphite_prefix}}"
-es_ip: "{{ lookup('env', 'ES') }}"

--- a/roles/undercloud-prepare-host/tasks/main.yml
+++ b/roles/undercloud-prepare-host/tasks/main.yml
@@ -67,7 +67,7 @@
   user:
     name: stack
     update_password: always
-    password: "{{ansible_ssh_pass}}"
+    password: "{{stack_password}}"
 
 - name: Sudo for stack user
   shell: |

--- a/roles/undercloud-prepare-host/templates/undercloud.10.conf.j2
+++ b/roles/undercloud-prepare-host/templates/undercloud.10.conf.j2
@@ -31,13 +31,11 @@ local_ip = 192.168.0.1/16
 network_gateway = 192.168.0.1
 
 # Virtual IP address to use for the public endpoints of Undercloud
-# services.  Only used if undercloud_service_certficate is set.
-# (string value)
+# services. Only used with SSL. (string value)
 #undercloud_public_vip = 192.0.2.2
 
 # Virtual IP address to use for the admin endpoints of Undercloud
-# services.  Only used if undercloud_service_certficate is set.
-# (string value)
+# services. Only used with SSL. (string value)
 #undercloud_admin_vip = 192.0.2.3
 
 # Certificate file to use for OpenStack service SSL connections.
@@ -69,6 +67,7 @@ network_gateway = 192.168.0.1
 
 # Network interface on the Undercloud that will be handling the PXE
 # boots and DHCP for Overcloud instances. (string value)
+#local_interface = eth1
 local_interface = {{local_interface}}
 
 # MTU to use for the local_interface. (integer value)
@@ -124,6 +123,7 @@ dhcp_end = 192.168.19.250
 # process.  Should not overlap with the range defined by dhcp_start
 # and dhcp_end, but should be in the same network. (string value)
 # Deprecated group/name - [DEFAULT]/discovery_iprange
+#inspection_iprange = 192.0.2.100,192.0.2.120
 inspection_iprange = 192.168.1.1,192.168.9.250
 
 # Whether to enable extra hardware collection during the inspection
@@ -138,7 +138,7 @@ inspection_iprange = 192.168.1.1,192.168.9.250
 
 # Whether to support introspection of nodes that have UEFI-only
 # firmware. (boolean value)
-#inspection_enable_uefi = false
+#inspection_enable_uefi = true
 
 # Whether to enable the debug log level for Undercloud OpenStack
 # services. (boolean value)
@@ -156,14 +156,19 @@ inspection_iprange = 192.168.1.1,192.168.9.250
 
 # Whether to install Telemetry services (ceilometer, aodh) in the
 # Undercloud. (boolean value)
-#enable_telemetry = false
+#enable_telemetry = true
 
-# Whether to use iPXE for deploy by default. (boolean value)
-#ipxe_deploy = true
+# Whether to install the TripleO UI. (boolean value)
+#enable_ui = true
 
-# Whether to install Monitoring services in the Undercloud. (boolean
-# value)
-#enable_monitoring = false
+# Whether to install requirements to run the TripleO validations.
+# (boolean value)
+#enable_validations = true
+
+# Whether to use iPXE for deploy and inspection. (boolean value)
+# Deprecated group/name - [DEFAULT]/ipxe_deploy
+#ipxe_enabled = true
+
 
 # Whether to store events in the Undercloud Ceilometer. (boolean
 # value)
@@ -174,10 +179,12 @@ inspection_iprange = 192.168.1.1,192.168.9.250
 # bare metal nodes you expect to deploy at once to work around
 # potential race condition when scheduling. (integer value)
 # Minimum value: 1
+#scheduler_max_attempts = 30
 scheduler_max_attempts = {{total_hosts}}
 
 # Whether to clean overcloud nodes (wipe the hard drive) between
 # deployments and after the introspection. (boolean value)
+#clean_nodes = false
 clean_nodes = {{node_cleaning}}
 
 
@@ -187,7 +194,7 @@ clean_nodes = {{node_cleaning}}
 # From instack-undercloud
 #
 
-# Password used for MySQL databases. If left unset, one will be
+# Password used for MySQL root user. If left unset, one will be
 # automatically generated. (string value)
 #undercloud_db_password = <None>
 

--- a/roles/undercloud-prepare-host/templates/undercloud.11.conf.j2
+++ b/roles/undercloud-prepare-host/templates/undercloud.11.conf.j2
@@ -4,11 +4,6 @@
 # From instack-undercloud
 #
 
-# Local file path to the necessary images. The path should be a
-# directory readable by the current user that contains the full set of
-# images. (string value)
-#image_path = .
-
 # Fully qualified hostname (including domain) to set on the
 # Undercloud. If left unset, the current hostname will be used, but
 # the user is responsible for configuring all system hostname settings
@@ -30,19 +25,22 @@ local_ip = 192.168.0.1/16
 #network_gateway = 192.168.24.1
 network_gateway = 192.168.0.1
 
-# Virtual IP address to use for the public endpoints of Undercloud
-# services. Only used with SSL. (string value)
-#undercloud_public_vip = 192.168.24.2
+# Virtual IP or DNS address to use for the public endpoints of
+# Undercloud services. Only used with SSL. (string value)
+# Deprecated group/name - [DEFAULT]/undercloud_public_vip
+#undercloud_public_host = 192.168.24.2
 
-# Virtual IP address to use for the admin endpoints of Undercloud
-# services. Only used with SSL. (string value)
-#undercloud_admin_vip = 192.168.24.3
+# Virtual IP or DNS address to use for the admin endpoints of
+# Undercloud services. Only used with SSL. (string value)
+# Deprecated group/name - [DEFAULT]/undercloud_admin_vip
+#undercloud_admin_host = 192.168.24.3
 
 # DNS nameserver(s) to use for the undercloud node. (list value)
 #undercloud_nameservers =
 
 # List of ntp servers to use. (list value)
-undercloud_ntp_servers = {{ ntp_server }}
+#undercloud_ntp_servers =
+undercloud_ntp_servers = {{ntp_server}}
 
 # Certificate file to use for OpenStack service SSL connections.
 # Setting this enables SSL for the OpenStack API endpoints, leaving it
@@ -53,7 +51,7 @@ undercloud_ntp_servers = {{ ntp_server }}
 # the undercloud install and this certificate will be used in place of
 # the value for undercloud_service_certificate.  The resulting
 # certificate will be written to
-# /etc/pki/tls/certs/undercloud-[undercloud_public_vip].pem.  This
+# /etc/pki/tls/certs/undercloud-[undercloud_public_host].pem.  This
 # certificate is signed by CA selected by the
 # "certificate_generation_ca" option. (boolean value)
 #generate_service_certificate = false
@@ -73,6 +71,7 @@ undercloud_ntp_servers = {{ ntp_server }}
 
 # Network interface on the Undercloud that will be handling the PXE
 # boots and DHCP for Overcloud instances. (string value)
+#local_interface = eth1
 local_interface = {{local_interface}}
 
 # MTU to use for the local_interface. (integer value)
@@ -100,8 +99,8 @@ dhcp_end = 192.168.19.250
 
 # Path to hieradata override file. If set, the file will be copied
 # under /etc/puppet/hieradata and set as the first file in the hiera
-# hierarchy. This can be used to to custom configure services beyond
-# what undercloud.conf provides (string value)
+# hierarchy. This can be used to custom configure services beyond what
+# undercloud.conf provides (string value)
 #hieradata_override =
 
 # Path to network config override template. If set, this template will
@@ -137,6 +136,19 @@ inspection_iprange = 192.168.1.1,192.168.9.250
 # firmware. (boolean value)
 #inspection_enable_uefi = true
 
+# Makes ironic-inspector enroll any unknown node that PXE-boots
+# introspection ramdisk in Ironic. By default, the "fake" driver is
+# used for new nodes (it is automatically enabled when this option is
+# set to True). Set discovery_default_driver to override.
+# Introspection rules can also be used to specify driver information
+# for newly enrolled nodes. (boolean value)
+#enable_node_discovery = false
+
+# The default driver to use for newly discovered nodes (requires
+# enable_node_discovery set to True). This driver is automatically
+# added to enabled_drivers. (string value)
+#discovery_default_driver = pxe_ipmitool
+
 # Whether to enable the debug log level for Undercloud OpenStack
 # services. (boolean value)
 #undercloud_debug = true
@@ -148,14 +160,7 @@ inspection_iprange = 192.168.1.1,192.168.9.250
 # Whether to install Tempest in the Undercloud. (boolean value)
 #enable_tempest = true
 
-# Whether to install Mistral services in the Undercloud. (boolean
-# value)
-#enable_mistral = true
-
-# Whether to install Zaqar services in the Undercloud. (boolean value)
-#enable_zaqar = true
-
-# Whether to install Telemetry services (ceilometer, aodh, gnocchi) in the
+# Whether to install Telemetry services (ceilometer, aodh) in the
 # Undercloud. (boolean value)
 #enable_telemetry = true
 
@@ -166,27 +171,39 @@ inspection_iprange = 192.168.1.1,192.168.9.250
 # (boolean value)
 #enable_validations = true
 
-# Whether to install the Volume service to be boot overcloud nodes
-# from remote volumes. (boolean value)
+# Whether to install the Volume service. It is not currently used in
+# the undercloud. (boolean value)
 #enable_cinder = false
+
+# Whether to enable legacy ceilometer api in the Undercloud. Note:
+# Ceilometer API has been deprecated and will be removed in future
+# release. Please consider moving to gnocchi/Aodh/Panko API instead.
+# (boolean value)
+#enable_legacy_ceilometer_api = true
+
+# Whether to install novajoin metadata service in the Undercloud.
+# (boolean value)
+#enable_novajoin = false
+
+# One Time Password to register Undercloud node with an IPA server.
+# Required when enable_novajoin = True. (string value)
+#ipa_otp =
 
 # Whether to use iPXE for deploy and inspection. (boolean value)
 # Deprecated group/name - [DEFAULT]/ipxe_deploy
 #ipxe_enabled = true
-
-# Whether to store events in the Undercloud Ceilometer. (boolean
-# value)
-#store_events = false
 
 # Maximum number of attempts the scheduler will make when deploying
 # the instance. You should keep it greater or equal to the number of
 # bare metal nodes you expect to deploy at once to work around
 # potential race condition when scheduling. (integer value)
 # Minimum value: 1
+#scheduler_max_attempts = 30
 scheduler_max_attempts = {{total_hosts}}
 
 # Whether to clean overcloud nodes (wipe the hard drive) between
 # deployments and after the introspection. (boolean value)
+#clean_nodes = false
 clean_nodes = {{node_cleaning}}
 
 # List of enabled bare metal drivers. (list value)
@@ -199,7 +216,7 @@ clean_nodes = {{node_cleaning}}
 # From instack-undercloud
 #
 
-# Password used for MySQL databases. If left unset, one will be
+# Password used for MySQL root user. If left unset, one will be
 # automatically generated. (string value)
 #undercloud_db_password = <None>
 
@@ -222,6 +239,10 @@ clean_nodes = {{node_cleaning}}
 # Heat service password. If left unset, one will be automatically
 # generated. (string value)
 #undercloud_heat_password = <None>
+
+# Heat cfn service password. If left unset, one will be automatically
+# generated. (string value)
+#undercloud_heat_cfn_password = <None>
 
 # Neutron service password. If left unset, one will be automatically
 # generated. (string value)
@@ -246,6 +267,10 @@ clean_nodes = {{node_cleaning}}
 # Ceilometer service password. If left unset, one will be
 # automatically generated. (string value)
 #undercloud_ceilometer_password = <None>
+
+# Panko service password. If left unset, one will be automatically
+# generated. (string value)
+#undercloud_panko_password = <None>
 
 # Ceilometer metering secret. If left unset, one will be automatically
 # generated. (string value)

--- a/roles/undercloud-prepare-host/templates/undercloud.12.conf.j2
+++ b/roles/undercloud-prepare-host/templates/undercloud.12.conf.j2
@@ -39,7 +39,8 @@ network_gateway = 192.168.0.1
 #undercloud_nameservers =
 
 # List of ntp servers to use. (list value)
-undercloud_ntp_servers = {{ ntp_server }}
+#undercloud_ntp_servers =
+undercloud_ntp_servers = {{ntp_server}}
 
 # DNS domain name to use when deploying the overcloud. The overcloud
 # parameter "CloudDomain" must be set to a matching value. (string
@@ -196,7 +197,11 @@ inspection_iprange = 192.168.1.1,192.168.9.250
 
 # Whether to enable docker container images to be build on the
 # undercloud. (boolean value)
-#enable_container_images_build = false
+#enable_container_images_build = true
+
+# Array of host/port combiniations of docker insecure registries.
+# (string value)
+#docker_insecure_registries =
 
 # One Time Password to register Undercloud node with an IPA server.
 # Required when enable_novajoin = True. (string value)
@@ -211,10 +216,12 @@ inspection_iprange = 192.168.1.1,192.168.9.250
 # bare metal nodes you expect to deploy at once to work around
 # potential race condition when scheduling. (integer value)
 # Minimum value: 1
+#scheduler_max_attempts = 30
 scheduler_max_attempts = {{total_hosts}}
 
 # Whether to clean overcloud nodes (wipe the hard drive) between
 # deployments and after the introspection. (boolean value)
+#clean_nodes = false
 clean_nodes = {{node_cleaning}}
 
 # List of enabled bare metal drivers. (list value)
@@ -235,7 +242,7 @@ clean_nodes = {{node_cleaning}}
 # From instack-undercloud
 #
 
-# Password used for MySQL databases. If left unset, one will be
+# Password used for MySQL root user. If left unset, one will be
 # automatically generated. (string value)
 #undercloud_db_password = <None>
 

--- a/roles/undercloud-prepare-host/templates/undercloud.13.conf.j2
+++ b/roles/undercloud-prepare-host/templates/undercloud.13.conf.j2
@@ -33,6 +33,7 @@ local_ip = 192.168.0.1/16
 #undercloud_nameservers =
 
 # List of ntp servers to use. (list value)
+#undercloud_ntp_servers =
 undercloud_ntp_servers = {{ntp_server}}
 
 # DNS domain name to use when deploying the overcloud. The overcloud
@@ -190,9 +191,13 @@ local_interface = {{local_interface}}
 # (boolean value)
 #enable_novajoin = false
 
-# Whether to install the Octavia client in the Undercloud. (boolean
-# value)
-#enable_octavia = false
+# Whether to enable docker container images to be build on the
+# undercloud. (boolean value)
+#enable_container_images_build = true
+
+# Array of host/port combiniations of docker insecure registries.
+# (string value)
+#docker_insecure_registries =
 
 # One Time Password to register Undercloud node with an IPA server.
 # Required when enable_novajoin = True. (string value)
@@ -371,6 +376,7 @@ clean_nodes = {{node_cleaning}}
 # Network CIDR for the Neutron-managed subnet for Overcloud instances.
 # (string value)
 # Deprecated group/name - [DEFAULT]/network_cidr
+#cidr = 192.168.24.0/24
 cidr = 192.168.0.0/16
 
 # Start of DHCP allocation range for PXE and DHCP of Overcloud
@@ -396,6 +402,7 @@ inspection_iprange = 192.168.1.1,192.168.9.250
 # Network gateway for the Neutron-managed network for Overcloud
 # instances on this network. (string value)
 # Deprecated group/name - [DEFAULT]/network_gateway
+#gateway = 192.168.24.1
 gateway = 192.168.0.1
 
 # The network will be masqueraded for external access. (boolean value)


### PR DESCRIPTION
Stack user password was being set incorrectly. Vars require further
organizing but lets just start by pruning whats not actually used
and is just cruft.

Lastly, lets keep commented vars in undercloud.conf so we can see what
was adjusted and what the default is.