### PR TITLE
Disable fact gather for rebuild and root ssh key exchange

### DIFF
--- a/deploy-scalelab.yaml
+++ b/deploy-scalelab.yaml
@@ -3,6 +3,14 @@
 # Playbook for deploying Tripleo OpenStack for OpenShift in ScaleLab
 #
 
+# Do not gather facts for rebuilding undercloud
+- name: Rebuild Undercloud
+  hosts: undercloud
+  gather_facts: false
+  remote_user: root
+  roles:
+    - rebuild-undercloud
+
 - name: Run initial setup tasks
   hosts: undercloud
   gather_facts: true
@@ -26,9 +34,7 @@
         path: "{{artifact_dir}}"
         state: directory
       delegate_to: localhost
-
   roles:
-    - rebuild-undercloud
     - undercloud-prepare-host
 
 - name: Run OSP install

--- a/roles/rebuild-undercloud/tasks/main.yml
+++ b/roles/rebuild-undercloud/tasks/main.yml
@@ -37,3 +37,9 @@
     port: 22
     delay: 600
     timeout: 2000
+
+# Depending on hardware rebuild, we may not have the ssh key exchanged
+- name: Setup root authorized key
+  authorized_key:
+    user: root
+    key: "{{ lookup('file', lookup('env','PUBLIC_KEY')| default('~/.ssh/id_rsa.pub', true)) }}"

--- a/roles/undercloud-prepare-host/tasks/main.yml
+++ b/roles/undercloud-prepare-host/tasks/main.yml
@@ -82,7 +82,7 @@
 - name: Setup authorized key upload
   authorized_key:
     user: stack
-    key: "{{ lookup('file', lookup('env','PUBLIC_KEY')) }}"
+    key: "{{ lookup('file', lookup('env','PUBLIC_KEY')| default('~/.ssh/id_rsa.pub', true)) }}"
 
 - name: Setup tripleo directories
   file:


### PR DESCRIPTION
Do not gather facts on a machine about to be rebuilt. Exchange ssh key rather
than relaying on ssh passwords.