### PR TITLE
Allow toggle to disable introspection completely

### DIFF
--- a/profiles/main.yml
+++ b/profiles/main.yml
@@ -11,11 +11,17 @@ build: "2017-07-22.2"
 
 overcloud_image_password: debug
 
+# Introspection parameters:
+# No introspection at all - adjusts instackenv to not require introspection
+instackenv_no_introspection: false
+node_provide_timeout: 1800
 # bulk introspection
 introspection: true
-
-# better introspection, be sure to turn bulk off if you use this
+# Introspection Script (Disable bulk if using)
 introspect_with_retry: false
+
+# Ironic automated cleaning (Use when introspection script is disabled)
+node_cleaning: true
 
 # Stack user password:
 # Make a new password:
@@ -24,9 +30,6 @@ stack_password: $6$rounds=656000$3ZalBI1dHsb8kfJI$XbtraTo6qcAfAHR158Wf4mLoUrDQsT
 
 # undercloud control plane interface:
 local_interface: em2
-
-# option to enable/disable ironic node cleaning on overcloud nodes
-node_cleaning: true
 
 external_network_vip: 172.21.0.10
 

--- a/profiles/openshift-deploy.yml
+++ b/profiles/openshift-deploy.yml
@@ -11,20 +11,23 @@ build: z4
 
 overcloud_image_password: debug
 
+# Introspection parameters:
+# No introspection at all - adjusts instackenv to not require introspection
+instackenv_no_introspection: "{{ lookup('env', 'OSP_INSTACKENV_NO_INTROSPECTION')|default(false, true) }}"
+node_provide_timeout: "{{ lookup('env', 'OSP_NODE_PROVIDE_TIMEOUT')|default(1800, true) }}"
 # bulk introspection
-introspection: false
+introspection: "{{ lookup('env', 'OSP_BULK_INTROSPECTION')|default(false, true) }}"
+# Introspection Script (Disable bulk if using)
+introspect_with_retry: "{{ lookup('env', 'OSP_INTROSPECTION_SCRIPT')|default(true, true) }}"
 
-# better introspection, be sure to turn bulk off if you use this
-introspect_with_retry: true
+# Ironic automated cleaning (Use when introspection script is disabled)
+node_cleaning: "{{ lookup('env', 'OSP_NODE_CLEANING')|default(false, true) }}"
 
 # Stack user password. Encrypted with sha512
 stack_password: "{{ lookup('env', 'STACK_PASSWORD') }}"
 
 # undercloud control plane interface:
 local_interface: enp94s0f1
-
-# option to enable/disable ironic node cleaning on overcloud nodes
-node_cleaning: false
 
 external_network_vip: "{{ lookup('env', 'EXTERNAL_NETWORK_VIP') }}"
 

--- a/profiles/openshift-staging.yml
+++ b/profiles/openshift-staging.yml
@@ -11,20 +11,23 @@ build: z4
 
 overcloud_image_password: debug
 
+# Introspection parameters:
+# No introspection at all - adjusts instackenv to not require introspection
+instackenv_no_introspection: "{{ lookup('env', 'OSP_INSTACKENV_NO_INTROSPECTION')|default(true, true) }}"
+node_provide_timeout: "{{ lookup('env', 'OSP_NODE_PROVIDE_TIMEOUT')|default(1800, true) }}"
 # bulk introspection
-introspection: false
+introspection: "{{ lookup('env', 'OSP_BULK_INTROSPECTION')|default(false, true) }}"
+# Introspection Script (Disable bulk if using)
+introspect_with_retry: "{{ lookup('env', 'OSP_INTROSPECTION_SCRIPT')|default(false, true) }}"
 
-# better introspection, be sure to turn bulk off if you use this
-introspect_with_retry: true
+# Ironic automated cleaning (Use when introspection script is disabled)
+node_cleaning: "{{ lookup('env', 'OSP_NODE_CLEANING')|default(true, true) }}"
 
 # Stack user password. Encrypted with sha512
 stack_password: "{{ lookup('env', 'STACK_PASSWORD') }}"
 
 # undercloud control plane interface:
 local_interface: enp94s0f1
-
-# option to enable/disable ironic node cleaning on overcloud nodes
-node_cleaning: false
 
 external_network_vip: "{{ lookup('env', 'EXTERNAL_NETWORK_VIP') }}"
 

--- a/roles/undercloud-install/tasks/main.yml
+++ b/roles/undercloud-install/tasks/main.yml
@@ -81,6 +81,14 @@
     owner: stack
     group: stack
 
+- name: Convert instackenv for no introspection
+  shell: |
+    set -o pipefail
+    cat /home/stack/instackenv.json | jq  '{ nodes: [ .nodes[] | .cpu="4" | .memory="60000" | .disk="50" |  .  ]}' > /home/stack/intermediate.json
+    python -m json.tool /home/stack/intermediate.json /home/stack/instackenv.json
+    rm -f /home/stack/intermediate.json
+  when: instackenv_no_introspection
+
 - name: Import instackenv.json
   shell: |
     . /home/stack/stackrc
@@ -91,7 +99,28 @@
     . /home/stack/stackrc
     openstack baremetal configure boot
 
+- name: No Introspection node provide Block
+  when: instackenv_no_introspection
+  block:
+    - name: Set Nodes to provide
+      shell: |
+        set -o pipefail
+        . /home/stack/stackrc
+        { time timeout {{node_provide_timeout}} openstack overcloud node provide --all-manageable 2>&1 | tee -a {{log_dir}}/overcloud-node-provide.log ; } 2>> {{log_dir}}/overcloud-node-provide.log
+  always:
+    - name: Collect instackenv.json
+      shell: |
+        cp /home/stack/instackenv.json {{log_dir}}/instackenv.json
+      ignore_errors: true
+
+    - name: Collect No Introspection node provide Artifacts
+      synchronize:
+        src: "{{log_dir}}"
+        dest: "{{artifact_dir}}/alderaan-deploy_log"
+        mode: pull
+
 - name: Introspection Script Block
+  when: instackenv_no_introspection == false
   block:
     - name: Template introspection script
       template:
@@ -108,6 +137,7 @@
       shell:  |
         set -o pipefail
         . /home/stack/stackrc
+        cp /home/stack/instackenv.json {{log_dir}}/instackenv.json
         openstack baremetal node list 2>&1 | tee -a {{log_dir}}/post-introspection-baremetal-node-list.log
         openstack baremetal node list | grep None | awk '{print $2}' | xargs -I % openstack baremetal node show % 2>&1 | tee -a {{log_dir}}/post-introspection-baremetal-node-show.log
 
@@ -118,6 +148,7 @@
         mode: pull
 
 - name: Introspection-data Block
+  when: instackenv_no_introspection == false
   block:
     - name: Generate introspection-data
       shell: |


### PR DESCRIPTION
We can use this to stand up the staging environment and potentially scale ci
environment much faster without the use of introspection.