### PR TITLE
Fix small mistake in templates

### DIFF
--- a/roles/overcloud-prepare-templates/templates/network-environment.yaml.j2
+++ b/roles/overcloud-prepare-templates/templates/network-environment.yaml.j2
@@ -24,7 +24,6 @@ parameter_defaults:
   StorageMgmtAllocationPools: [{'start': '172.19.0.3', 'end': '172.19.255.254'}]
   ManagementAllocationPools: [{'start': '172.20.0.3', 'end': '172.20.255.254'}]
   ExternalAllocationPools: [{'start': '{{external_network_pool_start}}', 'end': '{{external_network_pool_end}}'}]
-  # ExternalAllocationPools: [{'start': '{{172.21.0.3}}', 'end': '172.21.0.99'}]
   # Set to the router gateway on the external network
   ExternalInterfaceDefaultRoute: "{{external_network_gateway}}"
   PublicVirtualFixedIPs: [{'ip_address':'{{external_network_vip}}'}]


### PR DESCRIPTION
A comment added an AnsibleUndefinedVariable to the network-environment.yaml.j2

This line introduces the issue:

https://github.com/redhat-performance/tripleo-quickstart-scalelab/blob/32dae3370d84eebda25a98a01dec232c89e8a5f6/roles/overcloud-prepare-templates/templates/network-environment.yaml.j2#L27
