### PR TITLE
Use the build variable in the rhos-release command.

### DIFF
--- a/roles/undercloud-prepare-host/tasks/main.yml
+++ b/roles/undercloud-prepare-host/tasks/main.yml
@@ -28,7 +28,7 @@
   yum: name=/root/rhos-release.rpm
 
 - name: Setup OSP version to install
-  command: "rhos-release {{rhos_release}} -r {{rhel_version}}"
+  command: "rhos-release {{rhos_release}} -p {{build}} -r {{rhel_version}}"
 
 - name: Install utilities
   yum: name={{item}}


### PR DESCRIPTION
We are setting a build variable but not using it as we should be. For reference here is another project using the build variable.
https://github.com/redhat-performance/McCloud/blob/master/roles/000-undercloud-repos/tasks/main.yml#L24
