### PR TITLE
external_network_setup is a string compare against other strings.

### DIFF
--- a/profiles/main.yml
+++ b/profiles/main.yml
@@ -39,7 +39,7 @@ local_interface: "{{ lookup('env', 'OSP_UNDERCLOUD_LOCAL_INTERFACE')|default('en
 # External Network Setup:
 # 0 - private external network (Unlimited private floating ips)
 # 1 - public external network (Limited public floating ips)
-external_network_setup: "{{ lookup('env', 'OSP_EXTERNAL_NETWORK_SETUP')|default(0, true) }}"
+external_network_setup: "{{ lookup('env', 'OSP_EXTERNAL_NETWORK_SETUP')|default('0', true) }}"
 
 # Settings for both Network Setups
 dns_server: "{{ lookup('env', 'OSP_DNS_SERVER') }}"

--- a/profiles/openshift-deploy.yml
+++ b/profiles/openshift-deploy.yml
@@ -37,7 +37,7 @@ local_interface: "{{ lookup('env', 'OSP_UNDERCLOUD_LOCAL_INTERFACE')|default('en
 # External Network Setup:
 # 0 - private external network (Unlimited private floating ips)
 # 1 - public external network (Limited public floating ips)
-external_network_setup: "{{ lookup('env', 'OSP_EXTERNAL_NETWORK_SETUP')|default(0, true) }}"
+external_network_setup: "{{ lookup('env', 'OSP_EXTERNAL_NETWORK_SETUP')|default('0', true) }}"
 
 # Settings for both Network Setups
 dns_server: "{{ lookup('env', 'OSP_DNS_SERVER') }}"

--- a/profiles/openshift-staging.yml
+++ b/profiles/openshift-staging.yml
@@ -37,7 +37,7 @@ local_interface: "{{ lookup('env', 'OSP_UNDERCLOUD_LOCAL_INTERFACE')|default('en
 # External Network Setup:
 # 0 - private external network (Unlimited private floating ips)
 # 1 - public external network (Limited public floating ips)
-external_network_setup: "{{ lookup('env', 'OSP_EXTERNAL_NETWORK_SETUP')|default(0, true) }}"
+external_network_setup: "{{ lookup('env', 'OSP_EXTERNAL_NETWORK_SETUP')|default('0', true) }}"
 
 # Settings for both Network Setups
 dns_server: "{{ lookup('env', 'OSP_DNS_SERVER') }}"

--- a/roles/undercloud-prepare-host/tasks/main.yml
+++ b/roles/undercloud-prepare-host/tasks/main.yml
@@ -124,26 +124,23 @@
     owner: stack
     group: stack
 
-- name: Deploy private external vlan interface (external_network_setup - 0 only)
+- name: Deploy private external vlan interface (external_network_setup = 0 only)
   template:
     src: templates/ifcfg-vlan.j2
     dest: "/etc/sysconfig/network-scripts/ifcfg-{{undercloud_external_vlan_device}}"
     owner: root
     group: root
-  when:
-    - external_network_setup == 0
+  when: external_network_setup == "0"
 
-- name: Turn on private external vlan interface (external_network_setup - 0 only)
+- name: Turn on private external vlan interface (external_network_setup = 0 only)
   shell: ifup {{undercloud_external_vlan_device}}
-  when:
-    - external_network_setup == 0
+  when: external_network_setup == "0"
 
-- name: Setup traffic fowarding for private external network (external_network_setup - 0 only)
+- name: Setup traffic fowarding for private external network (external_network_setup = 0 only)
   shell: |
      echo 1 > /proc/sys/net/ipv4/ip_forward
      iptables -t nat -A POSTROUTING -o {{undercloud_public_interface}} -j MASQUERADE
      iptables -A FORWARD -i {{undercloud_public_interface}} -o {{undercloud_external_vlan_device}} -m state --state RELATED,ESTABLISHED -j ACCEPT
      iptables -A FORWARD -i {{undercloud_external_vlan_device}} -o {{undercloud_public_interface}} -j ACCEPT
      iptables-save > /etc/sysconfig/iptables
-  when:
-    - external_network_setup == 0
+  when: external_network_setup == "0"


### PR DESCRIPTION
I tested this in a small playbook. 
```yaml
---
- name: This tests the env fix
  hosts: localhost
  vars:
    external_network_setup: "{{ lookup('env', 'OSP_EXTERNAL_NETWORK_SETUP')|default(0, true) }}"
  tasks:
  
    - name: Task to print stuff
      debug:
        var: external_network_setup

    - name: Task to optionally skip
      debug:
        msg: "Run this task if the value is zero"
      when: external_network_setup == "0"
```