### PR TITLE
Changed order of nics to match, disabled unused nics, for consistency.

### DIFF
--- a/roles/overcloud-prepare-templates/files/nic-configs/private/1029p-cephstorage.yaml
+++ b/roles/overcloud-prepare-templates/files/nic-configs/private/1029p-cephstorage.yaml
@@ -77,10 +77,20 @@ resources:
         os_net_config:
           network_config:
             -
-              type: ovs_bridge
-              name: br-ex
-              use_dhcp: false
+              type: interface
+              name: eno1
               dns_servers: {get_param: DnsServers}
+              use_dhcp: true
+            -
+              type: interface
+              name: enp94s0f0
+              use_dhcp: false
+              defroute: false
+              onboot: false
+            -
+              type: ovs_bridge
+              name: br-sm
+              use_dhcp: false
               addresses:
                 -
                   ip_netmask:
@@ -92,11 +102,20 @@ resources:
                 -
                   ip_netmask: 169.254.169.254/32
                   next_hop: {get_param: EC2MetadataIp}
+                -
+                  default: false
+                  next_hop: {get_param: ControlPlaneDefaultRoute}
               members:
                 -
                   type: interface
                   name: enp94s0f1
                   primary: true
+                -
+                  type: vlan
+                  vlan_id: {get_param: StorageMgmtNetworkVlanID}
+                  addresses:
+                    -
+                      ip_netmask: {get_param: StorageMgmtIpSubnet}
             -
               type: ovs_bridge
               name: br-storage
@@ -112,19 +131,11 @@ resources:
                     -
                       ip_netmask: {get_param: StorageIpSubnet}
             -
-              type: ovs_bridge
-              name: br-sm
-              members:
-                -
-                  type: interface
-                  name: enp94s0f3
-                  primary: true
-                -
-                  type: vlan
-                  vlan_id: {get_param: StorageMgmtNetworkVlanID}
-                  addresses:
-                    -
-                      ip_netmask: {get_param: StorageMgmtIpSubnet}
+              type: interface
+              name: enp94s0f3
+              use_dhcp: false
+              defroute: false
+              onboot: false
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/roles/overcloud-prepare-templates/files/nic-configs/private/1029p-compute.yaml
+++ b/roles/overcloud-prepare-templates/files/nic-configs/private/1029p-compute.yaml
@@ -81,32 +81,10 @@ resources:
         os_net_config:
           network_config:
             -
-              type: ovs_bridge
-              name: br-ex
-              use_dhcp: false
+              type: interface
+              name: eno1
               dns_servers: {get_param: DnsServers}
-              addresses:
-                -
-                  ip_netmask:
-                    list_join:
-                      - '/'
-                      - - {get_param: ControlPlaneIp}
-                        - {get_param: ControlPlaneSubnetCidr}
-              routes:
-                -
-                  ip_netmask: 169.254.169.254/32
-                  next_hop: {get_param: EC2MetadataIp}
-              members:
-                -
-                  type: interface
-                  name: enp94s0f1
-                  primary: true
-                -
-                  type: vlan
-                  vlan_id: {get_param: InternalApiNetworkVlanID}
-                  addresses:
-                    -
-                      ip_netmask: {get_param: InternalApiIpSubnet}
+              use_dhcp: true
             -
               type: ovs_bridge
               name: br-tenant
@@ -123,6 +101,35 @@ resources:
                       ip_netmask: {get_param: TenantIpSubnet}
             -
               type: ovs_bridge
+              name: br-int
+              use_dhcp: false
+              addresses:
+                -
+                  ip_netmask:
+                    list_join:
+                      - '/'
+                      - - {get_param: ControlPlaneIp}
+                        - {get_param: ControlPlaneSubnetCidr}
+              routes:
+                -
+                  ip_netmask: 169.254.169.254/32
+                  next_hop: {get_param: EC2MetadataIp}
+                -
+                  default: false
+                  next_hop: {get_param: ControlPlaneDefaultRoute}
+              members:
+                -
+                  type: interface
+                  name: enp94s0f1
+                  primary: true
+                -
+                  type: vlan
+                  vlan_id: {get_param: InternalApiNetworkVlanID}
+                  addresses:
+                    -
+                      ip_netmask: {get_param: InternalApiIpSubnet}
+            -
+              type: ovs_bridge
               name: br-storage
               members:
                 -
@@ -135,6 +142,12 @@ resources:
                   addresses:
                     -
                       ip_netmask: {get_param: StorageIpSubnet}
+            -
+              type: interface
+              name: enp94s0f3
+              use_dhcp: false
+              defroute: false
+              onboot: false
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/roles/overcloud-prepare-templates/files/nic-configs/private/1029p-controller.yaml
+++ b/roles/overcloud-prepare-templates/files/nic-configs/private/1029p-controller.yaml
@@ -70,6 +70,9 @@ parameters:
     default: '24'
     description: The subnet CIDR of the control plane network.
     type: string
+  ControlPlaneDefaultRoute: # Override this via parameter_defaults
+    description: The default route of the control plane network.
+    type: string
   DnsServers: # Override this via parameter_defaults
     default: []
     description: A list of DNS servers (2 max for some implementations) that will be added to resolv.conf.
@@ -87,38 +90,10 @@ resources:
         os_net_config:
           network_config:
             -
-              type: ovs_bridge
-              name: br-ex
-              use_dhcp: false
+              type: interface
+              name: eno1
               dns_servers: {get_param: DnsServers}
-              addresses:
-                -
-                  ip_netmask:
-                    list_join:
-                      - '/'
-                      - - {get_param: ControlPlaneIp}
-                        - {get_param: ControlPlaneSubnetCidr}
-              routes:
-                -
-                  ip_netmask: 169.254.169.254/32
-                  next_hop: {get_param: EC2MetadataIp}
-              members:
-                -
-                  type: interface
-                  name: enp94s0f1
-                  primary: true
-                -
-                  type: vlan
-                  vlan_id: {get_param: ExternalNetworkVlanID}
-                  addresses:
-                    -
-                      ip_netmask: {get_param: ExternalIpSubnet}
-                -
-                  type: vlan
-                  vlan_id: {get_param: InternalApiNetworkVlanID}
-                  addresses:
-                    -
-                      ip_netmask: {get_param: InternalApiIpSubnet}
+              use_dhcp: true
             -
               type: ovs_bridge
               name: br-tenant
@@ -135,6 +110,41 @@ resources:
                       ip_netmask: {get_param: TenantIpSubnet}
             -
               type: ovs_bridge
+              name: br-int-sm
+              use_dhcp: false
+              addresses:
+                -
+                  ip_netmask:
+                    list_join:
+                      - '/'
+                      - - {get_param: ControlPlaneIp}
+                        - {get_param: ControlPlaneSubnetCidr}
+              routes:
+                -
+                  ip_netmask: 169.254.169.254/32
+                  next_hop: {get_param: EC2MetadataIp}
+                -
+                  default: false
+                  next_hop: {get_param: ControlPlaneDefaultRoute}
+              members:
+                -
+                  type: interface
+                  name: enp94s0f1
+                  primary: true
+                -
+                  type: vlan
+                  vlan_id: {get_param: InternalApiNetworkVlanID}
+                  addresses:
+                    -
+                      ip_netmask: {get_param: InternalApiIpSubnet}
+                -
+                  type: vlan
+                  vlan_id: {get_param: StorageMgmtNetworkVlanID}
+                  addresses:
+                    -
+                      ip_netmask: {get_param: StorageMgmtIpSubnet}
+            -
+              type: ovs_bridge
               name: br-storage
               members:
                 -
@@ -149,7 +159,7 @@ resources:
                       ip_netmask: {get_param: StorageIpSubnet}
             -
               type: ovs_bridge
-              name: br-sm
+              name: br-ex
               members:
                 -
                   type: interface
@@ -157,10 +167,10 @@ resources:
                   primary: true
                 -
                   type: vlan
-                  vlan_id: {get_param: StorageMgmtNetworkVlanID}
+                  vlan_id: {get_param: ExternalNetworkVlanID}
                   addresses:
                     -
-                      ip_netmask: {get_param: StorageMgmtIpSubnet}
+                      ip_netmask: {get_param: ExternalIpSubnet}
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/roles/overcloud-prepare-templates/files/nic-configs/private/1029u-cephstorage.yaml
+++ b/roles/overcloud-prepare-templates/files/nic-configs/private/1029u-cephstorage.yaml
@@ -77,10 +77,20 @@ resources:
         os_net_config:
           network_config:
             -
-              type: ovs_bridge
-              name: br-ex
-              use_dhcp: false
+              type: interface
+              name: eno1
               dns_servers: {get_param: DnsServers}
+              use_dhcp: true
+            -
+              type: interface
+              name: enp175s0f0
+              use_dhcp: false
+              defroute: false
+              onboot: false
+            -
+              type: ovs_bridge
+              name: br-sm
+              use_dhcp: false
               addresses:
                 -
                   ip_netmask:
@@ -92,11 +102,20 @@ resources:
                 -
                   ip_netmask: 169.254.169.254/32
                   next_hop: {get_param: EC2MetadataIp}
+                -
+                  default: false
+                  next_hop: {get_param: ControlPlaneDefaultRoute}
               members:
                 -
                   type: interface
                   name: enp175s0f1
                   primary: true
+                -
+                  type: vlan
+                  vlan_id: {get_param: StorageMgmtNetworkVlanID}
+                  addresses:
+                    -
+                      ip_netmask: {get_param: StorageMgmtIpSubnet}
             -
               type: ovs_bridge
               name: br-storage
@@ -112,19 +131,11 @@ resources:
                     -
                       ip_netmask: {get_param: StorageIpSubnet}
             -
-              type: ovs_bridge
-              name: br-sm
-              members:
-                -
-                  type: interface
-                  name: enp216s0f1
-                  primary: true
-                -
-                  type: vlan
-                  vlan_id: {get_param: StorageMgmtNetworkVlanID}
-                  addresses:
-                    -
-                      ip_netmask: {get_param: StorageMgmtIpSubnet}
+              type: interface
+              name: enp216s0f1
+              use_dhcp: false
+              defroute: false
+              onboot: false
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.


### PR DESCRIPTION
This is the result of discussion on networking and attempting to deploy in the cloud03 environment.

Fixes slow connection to ceph and makes the templates all refer to the nics in numerical order to make them easier to compare and possibly work with qnq0 since the nics match on other systems.