### PR TITLE
Do not use "br-int"

### DIFF
--- a/roles/overcloud-prepare-templates/files/nic-configs/private/1029p-compute.yaml
+++ b/roles/overcloud-prepare-templates/files/nic-configs/private/1029p-compute.yaml
@@ -101,7 +101,7 @@ resources:
                       ip_netmask: {get_param: TenantIpSubnet}
             -
               type: ovs_bridge
-              name: br-int
+              name: br-ctl-int
               use_dhcp: false
               addresses:
                 -

--- a/roles/overcloud-prepare-templates/files/nic-configs/public/1029p-compute.yaml
+++ b/roles/overcloud-prepare-templates/files/nic-configs/public/1029p-compute.yaml
@@ -101,7 +101,7 @@ resources:
                       ip_netmask: {get_param: TenantIpSubnet}
             -
               type: ovs_bridge
-              name: br-int
+              name: br-ctl-int
               use_dhcp: false
               dns_servers: {get_param: DnsServers}
               addresses:


### PR DESCRIPTION
br-int name is reserved for the OpenStack integration bridge

Through a series of edits to improve nic-configs (Public/Private implementation) regarding the length of OVS bridge names, bridge names were reduced since long bridges never get created.  Bridges were also named based off the "type" of network traffic expected (Ex. tenant traffic - br-tenant).  Incidently a bridge was named br-int inadvertently since internal api traffic was placed on a sole bridge (no longer carrying external traffic) Thus the bridge name changed from br-ex to br-internal and then shorterned to br-int.  Since this occured on a compute node where br-int is essential we ended up with a switching loop in the correct conditions.  In an ideal world, tripleo should not have validated or deployed a nic-config with a bridge named br-int but that is beyond the scope of this commit.