### PR TITLE
Adjustments to templates to remove 1029p composable role

### DIFF
--- a/roles/overcloud-prepare-templates/files/args.yaml
+++ b/roles/overcloud-prepare-templates/files/args.yaml
@@ -1,3 +1,2 @@
 parameter_defaults:
    ComputeKernelArgs: "intel_iommu=on iommu=pt"
-   ComputeHostnameFormat: "1029p"

--- a/roles/overcloud-prepare-templates/files/compute-params.yaml
+++ b/roles/overcloud-prepare-templates/files/compute-params.yaml
@@ -3,7 +3,7 @@ parameter_defaults:
     - vendor_id: "144d"
       product_id: "a804"
       device_type: "type-PCI"
-  1029PComputeExtraConfig:
+  ComputeExtraConfig:
     nova::pci::aliases:
        - name: 'nvme'
          product_id: 'a804'

--- a/roles/overcloud-prepare-templates/files/first-boot.yaml
+++ b/roles/overcloud-prepare-templates/files/first-boot.yaml
@@ -12,9 +12,9 @@ parameters:
       Example: "intel_iommu=on"
     type: string
     default: ""
-  ComputeHostnameFormat:
+  ComputePassthroughHostnameFormat:
     type: string
-    default: ""
+    default: "compute"
 
 resources:
   userdata:
@@ -32,7 +32,7 @@ resources:
           template: |
             #!/bin/bash
             set -x
-            FORMAT=$COMPUTE_HOSTNAME_FORMAT
+            FORMAT=$COMPUTE_PASSTHROUGH_HOSTNAME_FORMAT
             if [[ $(hostname) == *$FORMAT* ]] ; then
               sed "s/^\(GRUB_CMDLINE_LINUX=\".*\)\"/\1 $KERNEL_ARGS\"/g" -i /etc/default/grub ;
               grub2-mkconfig -o /etc/grub2.cfg
@@ -67,7 +67,7 @@ resources:
             fi
           params:
             $KERNEL_ARGS: {get_param: ComputeKernelArgs}
-            $COMPUTE_HOSTNAME_FORMAT: {get_param: ComputeHostnameFormat}
+            $COMPUTE_PASSTHROUGH_HOSTNAME_FORMAT: {get_param: ComputePassthroughHostnameFormat}
 
 outputs:
   # This means get_resource from the parent template will get the userdata, see:

--- a/roles/overcloud-prepare-templates/files/roles_data-notelem.yaml
+++ b/roles/overcloud-prepare-templates/files/roles_data-notelem.yaml
@@ -95,7 +95,7 @@
     #- OS::TripleO::Services::GnocchiStatsd
     - OS::TripleO::Services::ManilaApi
     - OS::TripleO::Services::ManilaScheduler
-    # - OS::TripleO::Services::ManilaBackendGeneric
+    #- OS::TripleO::Services::ManilaBackendGeneric
     - OS::TripleO::Services::ManilaBackendNetapp
     - OS::TripleO::Services::ManilaBackendCephFs
     - OS::TripleO::Services::ManilaShare
@@ -130,9 +130,9 @@
     - OS::TripleO::Services::OctaviaHousekeeping
     - OS::TripleO::Services::OctaviaWorker
 
-- name: P1029Compute
-  CountDefault: 0
-  HostnameFormatDefault: '%stackname%-1029pcompute-%index%'
+- name: Compute
+  CountDefault: 1
+  HostnameFormatDefault: '%stackname%-compute-%index%'
   disable_upgrade_deployment: True
   ServicesDefault:
     - OS::TripleO::Services::CACerts
@@ -147,7 +147,7 @@
     - OS::TripleO::Services::Kernel
     - OS::TripleO::Services::ComputeNeutronCorePlugin
     - OS::TripleO::Services::ComputeNeutronOvsAgent
-    - OS::TripleO::Services::ComputeCeilometerAgent
+    #- OS::TripleO::Services::ComputeCeilometerAgent
     - OS::TripleO::Services::ComputeNeutronL3Agent
     - OS::TripleO::Services::ComputeNeutronMetadataAgent
     - OS::TripleO::Services::TripleoPackages

--- a/roles/overcloud-prepare-templates/files/scheduler-hints.yaml
+++ b/roles/overcloud-prepare-templates/files/scheduler-hints.yaml
@@ -1,7 +1,7 @@
 parameter_defaults:
   ControllerSchedulerHints:
     'capabilities:node': 'controller-%index%'
-  P1029ComputeSchedulerHints:
-    'capabilities:node': '1029pcompute-%index%'
   CephStorageSchedulerHints:
     'capabilities:node': 'cephstorage-%index%'
+  ComputeSchedulerHints:
+    'capabilities:node': 'compute-%index%'


### PR DESCRIPTION
Since we have an LTA on 1029p machines, we no longer currently need composable roles for
compute nodes.