### PR TITLE
Fix compute node pinning

### DIFF
--- a/roles/overcloud-prepare-templates/files/roles_data-notelem.yaml
+++ b/roles/overcloud-prepare-templates/files/roles_data-notelem.yaml
@@ -132,7 +132,6 @@
 
 - name: Compute
   CountDefault: 1
-  HostnameFormatDefault: '%stackname%-compute-%index%'
   disable_upgrade_deployment: True
   ServicesDefault:
     - OS::TripleO::Services::CACerts

--- a/roles/overcloud-prepare-templates/tasks/main.yml
+++ b/roles/overcloud-prepare-templates/tasks/main.yml
@@ -27,8 +27,6 @@
       dest: /home/stack/templates/firstboot/first-boot.yaml
     - src: files/roles_data-notelem.yaml
       dest: /home/stack/templates/roles_data-notelem.yaml
-    - src: files/scheduler-hints.yaml
-      dest: /home/stack/templates/scheduler-hints.yaml
 
     # Private External Nic-config "templates"
     - src: files/nic-configs/private/1029p-cephstorage.yaml
@@ -60,6 +58,8 @@
       dest: /home/stack/templates/deploy.yaml
     - src: templates/network-environment.yaml.j2
       dest: /home/stack/templates/network-environment.yaml
+    - src: templates/scheduler-hints.yaml.j2
+      dest: /home/stack/templates/scheduler-hints.yaml
 
 - name: Place version metadata json file in /etc
   become: true

--- a/roles/overcloud-prepare-templates/templates/scheduler-hints.yaml.j2
+++ b/roles/overcloud-prepare-templates/templates/scheduler-hints.yaml.j2
@@ -3,5 +3,10 @@ parameter_defaults:
     'capabilities:node': 'controller-%index%'
   CephStorageSchedulerHints:
     'capabilities:node': 'cephstorage-%index%'
+{% if version == '11' %}
+  NovaComputeSchedulerHints:
+    'capabilities:node': 'novacompute-%index%'
+{% else %}
   ComputeSchedulerHints:
-    'capabilities:node': 'compute-%index%'
+    'capabilities:node': 'novacompute-%index%'
+{% endif %}

--- a/roles/undercloud-install/tasks/main.yml
+++ b/roles/undercloud-install/tasks/main.yml
@@ -22,14 +22,14 @@
       with_items:
         - /etc/httpd/conf.d/10-keystone_wsgi_admin.conf
         - /etc/httpd/conf.d/10-keystone_wsgi_main.conf
-      when: version == 11
+      when: version == '11'
 
     - name: OSP11/Ocata - Restart httpd hosting Keystone
       become: true
       service:
         name: httpd
         state: restarted
-      when: version == 11
+      when: version == '11'
 
     - name: Install ipa and overcloud images
       become: true

--- a/vars/deploy.yml
+++ b/vars/deploy.yml
@@ -5,7 +5,7 @@
 rhos_release_rpm: "{{ lookup('env', 'OSP_RHOS_RELEASE_URL') }}"
 
 # OSP/OSPd versioning and build
-version: "{{ lookup('env', 'OSP_RHOS_VERSION')|default(11, true) }}"
+version: "{{ lookup('env', 'OSP_RHOS_VERSION')|default('11', true) }}"
 rhel_version: "{{ lookup('env', 'OSP_RHOS_RHEL_VERSION')|default(7.4, true) }}"
 rhos_release: "{{ lookup('env', 'OSP_RHOS_RELEASE_VERSION')|default('11-director', true) }}"
 build: "{{ lookup('env', 'OSP_RHOS_BUILD')|default('z4', true) }}"
@@ -52,7 +52,7 @@ total_hosts: "{{ num_controllers|int + num_compute|int + num_storage|int }}"
 
 openstack_deployment_hosts:
   - host_type:
-      pin: compute
+      pin: novacompute
       title: Compute
       hint: "{{compute_type}}"
       count: "{{num_compute}}"


### PR DESCRIPTION
OSP12/13 uses "ComputeSchedulerHints"
OSP10/11 uses "NovaComputeSchedulerHints"

This patch templates those out per version.

We also use the typical "novacompute" vs "compute-" which is the default. We
should not need to set the hostname default format either.