### PR TITLE
Speedup Browbeat install with bootstrap.py

### DIFF
--- a/install-browbeat.yaml
+++ b/install-browbeat.yaml
@@ -37,7 +37,7 @@
       shell: |
         cd /home/stack/browbeat/ansible
         . /home/stack/stackrc
-        /home/stack/browbeat/ansible/generate_tripleo_hostfile.sh -l
+        /home/stack/browbeat/ansible/bootstrap.py tripleo
 
     - name: Configure Browbeat Monitoring
       lineinfile:


### PR DESCRIPTION
Use bootstrap.py for speed up.  We need this (https://review.openstack.org/#/c/579656/)
to be merged before merging this.  The speed up for staging is 2.6s vs 73s.  The gain
is larger for larger clouds (scale-ci)