### PR TITLE
Minor fix for using bootstrap.py

### DIFF
--- a/install-browbeat.yaml
+++ b/install-browbeat.yaml
@@ -37,6 +37,8 @@
       shell: |
         cd /home/stack/browbeat/ansible
         . /home/stack/stackrc
+        cat /home/stack/.ssh/id_rsa.pub >> /home/stack/.ssh/authorized_keys
+        chmod 0600 /home/stack/.ssh/authorized_keys
         /home/stack/browbeat/ansible/bootstrap.py tripleo
 
     - name: Configure Browbeat Monitoring


### PR DESCRIPTION
Stack user requires the ssh key to be exchanged with the Undercloud machine. In
this case that turns out to be the same machine as the stack user is on.  The
previous generate_tripleo_hostfile.sh script did this for us.