### PR TITLE
Writing a script to create networks, and call the script.

### DIFF
--- a/roles/overcloud-prepare-templates/tasks/main.yml
+++ b/roles/overcloud-prepare-templates/tasks/main.yml
@@ -31,3 +31,11 @@
     dest: /etc/version.json
     owner: stack
     group: stack
+
+- name: Render the network setup script
+  template:
+    src: templates/create_public_cluster_network.sh.j2
+    dest: /home/stack/alderaan-deploy/create_public_cluster_network.sh
+    mode: 0755
+    owner: stack
+    group: stack

--- a/roles/overcloud-prepare-templates/templates/create_public_cluster_network.sh.j2
+++ b/roles/overcloud-prepare-templates/templates/create_public_cluster_network.sh.j2
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -x
+openstack network create --share --external --provider-physical-network datacentre --provider-network-type vlan --provider-segment {{ external_vlan }} public --format json
+openstack subnet create --allocation-pool start={{fip_pool_start}},end={{fip_pool_end}} --gateway={{external_network_gateway}} --no-dhcp --dns-nameserver {{dns_server}} --network public --subnet-range {{external_network_cidr}} public_subnet --format json

--- a/roles/scalelab-network/tasks/main.yml
+++ b/roles/scalelab-network/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
 # Create a basic network environment for the tenant with the DNS set.
-- name: Create public network
-  shell: "source /home/stack/overcloudrc; openstack network create --share --external --provider-physical-network datacentre --provider-network-type vlan --provider-segment {{ external_vlan }} public --format json"
-
-# Create a subnet of floating IPs with start, end, gateway and range from variables.
-- name: Create a public subnet floating ip pool
-  shell: "source /home/stack/overcloudrc; openstack subnet create --allocation-pool start={{fip_pool_start}},end={{fip_pool_end}} --gateway={{external_network_gateway}} --no-dhcp --dns-nameserver {{dns_server}} --network public --subnet-range {{external_network_cidr}} public_subnet --format json"
+- name: Create network and subnet for the tenant
+  shell: ". /home/stack/overcloudrc; /home/stack/alderaan-deploy/create_public_cluster_network.sh"


### PR DESCRIPTION
The past few OpenStack deploys have failed, with manual intervention needed to complete the install. The network creation steps are the last things the automation performs and we always have to enter these commands by hand.

This change writes a script with the network creation commands early so we don't have to manually recreate the individual commands.