### PR TITLE
Use scale lab provided script to clean validation addresses and vlans

### DIFF
--- a/roles/undercloud-prepare-host/tasks/main.yml
+++ b/roles/undercloud-prepare-host/tasks/main.yml
@@ -4,12 +4,7 @@
 # Scale Lab Pre-deployment tooling lays down vlans to test network before hand
 # Lets remove this to avoid confusion when debugging and to prevent vlan conflicts
 - name: Clean Validation vlans
-  shell: |
-    for interface in $(ip -o link show | awk '{print $2}' | grep "@"  | awk '{split($0,interface,"@"); print interface[1]}')
-    do
-      ifdown ${interface}
-      rm /etc/sysconfig/network-scripts/ifcfg-${interface}
-    done
+  command: /root/clean-interfaces.sh --nuke
 
 - name: Disable epel
   shell: rpm -e epel-release


### PR DESCRIPTION
In order to reduce confusion and potential for network conflict, we run the
script that the scale lab provides to remove validation addresses and vlans
in order to simulate receiving a clean machine without any configured addresses
on its interfaces.