### PR TITLE
Changes for OSP13

### DIFF
--- a/roles/overcloud-deploy/files/pin.py
+++ b/roles/overcloud-deploy/files/pin.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import argparse
+import os
+import sys
+import time
+
+from ironicclient import client
+
+"""
+Script to pin nodes based on a hint within the ipmi hostname.
+
+Examples:
+pin.py -n 3 -p controller --hint 1029p -c
+pin.py -n 39 -p novacompute --hint 1029p
+pin.py -n 5 -p cephstorage --hint 1029u
+
+Example pins 3 1029p nodes as controllers, 39 as compute nodes, and 5 1029u as ceph storage nodes.
+"""
+
+
+def set_capablities(ironic, uuid, capabilities):
+    """Sets or Capabilities on OpenStack Ironic Node"""
+    patch = [
+        {
+            "op": "replace",
+            "path": "/properties/capabilities",
+            "value": capabilities,
+        }
+    ]
+    ironic.node.update(uuid, patch=patch)
+
+start_time = time.time()
+
+parser = argparse.ArgumentParser(
+        description="Pin nodes to node type based on hint", prog="pin.py")
+parser.add_argument("-n", "--nodes", type=int, required=True, help="Number of Nodes to pin")
+parser.add_argument("--hint", type=str, required=True, help="Hint in ironic node properties")
+parser.add_argument("-p", "--pin", type=str, required=True, help="Role to pin nodes")
+parser.add_argument("-c", "--clear", action="store_true", default=False, help="Clear existing pins")
+
+cliargs = parser.parse_args()
+
+print "INFO :: pin.py node count: {}".format(cliargs.nodes)
+print "INFO :: pin.py hint: {}".format(cliargs.hint)
+print "INFO :: pin.py pin: {}".format(cliargs.pin)
+print "INFO :: pin.py clear: {}".format(cliargs.clear)
+
+if "OS_PROJECT_NAME" in os.environ:
+    project_name = os.environ["OS_PROJECT_NAME"]
+elif "OS_TENANT_NAME" in os.environ:
+    project_name = os.environ["OS_TENANT_NAME"]
+else:
+    print "ERROR :: Missing OS_PROJECT_NAME or OS_TENANT_NAME in rc file"
+    exit(1)
+
+user_domain_name = None
+if "OS_USER_DOMAIN_NAME" in os.environ:
+    user_domain_name = os.environ["OS_USER_DOMAIN_NAME"]
+project_domain_name = None
+if "OS_PROJECT_DOMAIN_NAME" in os.environ:
+    project_domain_name = os.environ["OS_PROJECT_DOMAIN_NAME"]
+
+# Establish Ironic API Connection
+ironic = client.get_client(
+        1, os_username=os.environ["OS_USERNAME"], os_password=os.environ["OS_PASSWORD"],
+        os_auth_url=os.environ["OS_AUTH_URL"], os_project_name=project_name,
+        os_user_domain_name=user_domain_name, os_project_domain_name=project_domain_name)
+
+# Get Ironic nodes (once)
+nodes = ironic.node.list()
+
+# Clear Ironic Node Pinning
+if cliargs.clear:
+    print "INFO :: Clearing existing pins"
+    for node in nodes:
+        properties = ironic.node.get(node.uuid).properties
+        if "node" in str(properties["capabilities"]):
+            ipmi_addr = ironic.node.get(node.uuid).to_dict()["driver_info"]["ipmi_address"]
+            print "INFO :: Node {} ({}) with pin: {}".format(
+                    ipmi_addr, node.uuid, properties["capabilities"])
+            data = properties["capabilities"].split(",")
+            new_cap = ",".join([item for item in data if "node" not in item])
+            print "INFO :: Setting capabilities: {} for node {} ({})".format(
+                    new_cap, ipmi_addr, node.uuid)
+            set_capablities(ironic, node.uuid, new_cap)
+    print "INFO :: Finished Clearing existing pins"
+
+# Perform requested pinning based on a hint
+for node_idx in range(cliargs.nodes):
+    node_pinned = False
+    print "INFO :: Pinning Node: {}".format(node_idx)
+    for node in nodes:
+        properties = ironic.node.get(node.uuid).properties
+        if "node" not in str(properties["capabilities"]):
+            ipmi_addr = ironic.node.get(node.uuid).to_dict()["driver_info"]["ipmi_address"]
+            if cliargs.hint in ipmi_addr:
+                print "INFO :: Node {} ({}) pinning to: {}".format(
+                        ipmi_addr, node.uuid, properties["capabilities"])
+                data = properties["capabilities"].split(",")
+                data.append("node:{}-{}".format(cliargs.pin, node_idx))
+                new_cap = ",".join(data)
+                print "INFO :: Setting capabilities: {} for node {} ({})".format(
+                        new_cap, ipmi_addr, node.uuid)
+                set_capablities(ironic, node.uuid, new_cap)
+                node_pinned = True
+                break
+    # Exit/Fail if we can not pin a node
+    if not node_pinned:
+        print "ERROR :: Could not pin: {} to hint: {}".format(node_idx, cliargs.hint)
+        exit(1)
+
+print "INFO :: Took {} to pin nodes.".format(round(time.time() - start_time, 2))
+exit(0)

--- a/roles/overcloud-deploy/tasks/main.yml
+++ b/roles/overcloud-deploy/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # tasks file for overcloud-deploy
 
-- name: Install ostag
+- name: OSP11 Install ostag
   pip:
     state: latest
     virtualenv: /home/stack/alderaan-deploy/ostag-venv
@@ -9,12 +9,21 @@
   with_items:
     - pip
     - git+https://github.com/redhat-performance/ostag#egg=ostag
+  when: version == '11'
 
-- name: Fix os-client-config version for ostag
+- name: OSP11 Fix os-client-config version for ostag
   pip:
     name: os-client-config
     version: 1.29.0
     virtualenv: /home/stack/alderaan-deploy/ostag-venv
+  when: version == '11'
+
+- name: OSP13 Copy pin python script to Undercloud
+  copy:
+    src: pin.py
+    dest: /home/stack/alderaan-deploy/pin.py
+    mode: 0744
+  when: version == '13'
 
 - name: Template the Pinning script
   template:

--- a/roles/overcloud-deploy/templates/pin-nodes.sh.j2
+++ b/roles/overcloud-deploy/templates/pin-nodes.sh.j2
@@ -1,7 +1,19 @@
 #!/bin/bash
+{%if version == '13' %}
+
+set -eux
+/home/stack/alderaan-deploy/pin.py -n {{num_controllers}} -p controller --hint {{controller_type}} -c
+{% for node_type in openstack_deployment_hosts %}
+/home/stack/alderaan-deploy/pin.py -n {{node_type['host_type']['count']}} -p {{node_type['host_type']['pin']}} --hint {{node_type['host_type']['hint']}}
+{% endfor %}
+
+{% else %}
+
 source /home/stack/alderaan-deploy/ostag-venv/bin/activate
 set -eux
 ostag -n {{num_controllers}} -p controller --hint {{controller_type}} -c
 {% for node_type in openstack_deployment_hosts %}
 ostag -n {{node_type['host_type']['count']}} -p {{node_type['host_type']['pin']}} --hint {{node_type['host_type']['hint']}}
 {% endfor %}
+
+{% endif %}

--- a/roles/undercloud-introspection/tasks/main.yml
+++ b/roles/undercloud-introspection/tasks/main.yml
@@ -24,17 +24,24 @@
     cat /home/stack/instackenv.json | jq  '{ nodes: [ .nodes[] | .cpu="4" | .memory="60000" | .disk="50" |  .  ]}' > /home/stack/intermediate.json
     python -m json.tool /home/stack/intermediate.json /home/stack/instackenv.json
     rm -f /home/stack/intermediate.json
-  when: instackenv_no_introspection
+  when: instackenv_no_introspection|bool
 
 - name: Import instackenv.json
   shell: |
     . /home/stack/stackrc
-    openstack baremetal import --json /home/stack/instackenv.json
+    openstack overcloud node import /home/stack/instackenv.json
 
-- name: Configure boot
+- name: OSP11 Configure boot
   shell: |
     . /home/stack/stackrc
     openstack baremetal configure boot
+  when: version == '11'
+
+- name: OSP13 Configure boot
+  shell: |
+    . /home/stack/stackrc
+    openstack overcloud node configure --all-manageable
+  when: version == '13'
 
 - name: Copy introspection script to Undercloud
   copy:
@@ -45,7 +52,7 @@
     mode: 0744
 
 - name: No Introspection node provide Block
-  when: instackenv_no_introspection
+  when: instackenv_no_introspection|bool
   block:
     - name: Set Nodes to provide
       shell: |
@@ -65,8 +72,8 @@
 
 - name: Bulk Introspection Block
   when:
-    - introspection
-    - not introspect_with_retry
+    - introspection|bool
+    - not introspect_with_retry|bool
   block:
     - name: Run bulk introspection
       shell:  |
@@ -90,8 +97,8 @@
 
 - name: Introspection Script Block
   when:
-    - introspection
-    - introspect_with_retry
+    - introspection|bool
+    - introspect_with_retry|bool
   block:
     - name: Run introspection with retry script
       shell: |
@@ -114,8 +121,8 @@
 
 - name: Introspection-data Block
   when:
-    - instackenv_no_introspection == false
-    - introspection
+    - not instackenv_no_introspection|bool
+    - introspection|bool
   block:
     - name: Generate introspection-data
       shell: |

--- a/vars/deploy.yml
+++ b/vars/deploy.yml
@@ -8,7 +8,7 @@ rhos_release_rpm: "{{ lookup('env', 'OSP_RHOS_RELEASE_URL') }}"
 version: "{{ lookup('env', 'OSP_RHOS_VERSION')|default('13', true) }}"
 rhel_version: "{{ lookup('env', 'OSP_RHOS_RHEL_VERSION')|default('7.5', true) }}"
 rhos_release: "{{ lookup('env', 'OSP_RHOS_RELEASE_VERSION')|default('13-director', true) }}"
-build: "{{ lookup('env', 'OSP_RHOS_BUILD')|default('ga', true) }}"
+build: "{{ lookup('env', 'OSP_RHOS_BUILD')|default('GA', true) }}"
 
 # OSP13 only:
 additional_insecure_registry: "{{ lookup('env', 'OSP_INSECURE_REGISTRY')|default('', true) }}"


### PR DESCRIPTION
ostag requires several fixes to work correctly with OSP13, rather
than manage the dependencies across several repos, it is easier to
create a python script that interacts directly with the Ironic API
in order to pin nodes as we need.  There are also some Ansible
logic issues fixed such as variables not evaluating correctly
without a filter (Ex. |bool)