### PR TITLE
Adjust Ceph pg count very low for OSP13

### DIFF
--- a/roles/overcloud-prepare-templates/templates/1029p-storage-environment.yaml.j2
+++ b/roles/overcloud-prepare-templates/templates/1029p-storage-environment.yaml.j2
@@ -18,7 +18,7 @@ parameter_defaults:
 
   CephPools:
     - name: images
-      pg_num: 64
+      pg_num: 8
       rule_name: ""
     - name: metrics
       pg_num: 8
@@ -27,7 +27,7 @@ parameter_defaults:
       pg_num: 8
       rule_name: ""
     - name: vms
-      pg_num: 64
+      pg_num: 8
       rule_name: ""
     - name: volumes
       pg_num: 8

--- a/roles/overcloud-prepare-templates/templates/1029u-storage-environment.yaml.j2
+++ b/roles/overcloud-prepare-templates/templates/1029u-storage-environment.yaml.j2
@@ -18,7 +18,7 @@ parameter_defaults:
 
   CephPools:
     - name: images
-      pg_num: 256
+      pg_num: 16
       rule_name: ""
     - name: metrics
       pg_num: 16
@@ -27,10 +27,10 @@ parameter_defaults:
       pg_num: 16
       rule_name: ""
     - name: vms
-      pg_num: 1024
+      pg_num: 16
       rule_name: ""
     - name: volumes
-      pg_num: 256
+      pg_num: 16
       rule_name: ""
 
   #### BACKEND SELECTION ####


### PR DESCRIPTION
There is a bug with Ceph Ansible in that pg/pgp count
should be adjust post overcloud deployed.  In this case
we set the pg/pgp count very low and will add post
overcloud deploy workaround to tune the pg/pgp count to
the correct size.