### PR TITLE
Renaming a role to perform post deploy tasks.

### DIFF
--- a/deploy-scalelab.yaml
+++ b/deploy-scalelab.yaml
@@ -56,4 +56,4 @@
     - undercloud-introspection
     - overcloud-prepare-templates
     - overcloud-deploy
-    - scalelab-network
+    - post-deploy

--- a/roles/post-deploy/tasks/main.yml
+++ b/roles/post-deploy/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+# Tasks to run after OpenStack has finished deploying.
+
+- name: Create a network and subnet with DNS
+  shell: ". /home/stack/overcloudrc; /home/stack/alderaan-deploy/create_public_cluster_network.sh"
+
+- name: Getting the list of servers from OpenStack
+  shell: ". /home/stack/stackrc; server list --format value -c Name -c Networks --limit -1"
+  # Example output: overcloud-compute-15 ctlplane=192.168.10.2
+  register: name_networks
+  changed_when: false
+
+- name: Creating an ssh command that will use {{ inventory_hostname }} as a proxy
+  set_fact:
+    # The key path must be from the remote host not the openstack-server.
+    proxy_command: "ssh -i {{ ansible_private_key_file }} -W %h:%p {{ ansible_user }}@{{ inventory_hostname }}"
+
+- name: Adding the OpenStack servers to the in-memory inventory with groups
+  add_host:
+    name: "{{ item.split('=')[1] }}"
+    groups: [ "{{ item.split('-')[1].split('-')[0] }}" ]
+    ansible_user: heat-admin
+    # Adding a ProxyCommand allows ansbile to contact this IP using the openstack-server.
+    ansible_ssh_common_args: "-o ProxyCommand='{{ proxy_command }}'"
+  with_items: "{{ name_networks.stdout_lines }}"
+
+- name: Set the ceph values on the controller server
+  shell: |
+    ceph osd pool set {{ item.pool_name }} pg_num {{ item.pg_num }}
+    ceph osd pool set {{ item.pool_name }} pgp_num {{ item.pg_num }}
+  with_items: "{{ ceph_pools }}"
+  become: true
+  delegate_to: "{{ groups.controller[0] }}"

--- a/roles/scalelab-network/tasks/main.yml
+++ b/roles/scalelab-network/tasks/main.yml
@@ -1,4 +1,0 @@
----
-# Create a basic network environment for the tenant with the DNS set.
-- name: Create network and subnet for the tenant
-  shell: ". /home/stack/overcloudrc; /home/stack/alderaan-deploy/create_public_cluster_network.sh"

--- a/roles/undercloud-prepare-host/tasks/main.yml
+++ b/roles/undercloud-prepare-host/tasks/main.yml
@@ -67,6 +67,30 @@
 - name: Add stack user
   user: name=stack
 
+- name: Creating the /home/stack/.ssh directory on the server
+  file:
+    path: "/home/stack/.ssh"
+    state: directory
+    mode: 0700
+    owner: stack
+    group: stack
+
+- name: Copying the private key to the server
+  copy:
+    src: "{{ ansible_private_key_file }}"
+    dest: "/home/stack/.ssh/id_rsa"
+    mode: 0600
+    owner: stack
+    group: stack
+
+- name: Copying the public key to the server
+  copy:
+    src: "{{ ansible_public_key_file }}"
+    dest: "/home/stack/.ssh/id_rsa.pub"
+    mode: 0644
+    owner: stack
+    group: stack
+
 # Not entirely sure why the password wouldn't take with the initial command
 - name: Stack user password
   user:
@@ -82,7 +106,7 @@
 - name: Setup authorized key upload
   authorized_key:
     user: stack
-    key: "{{ lookup('file', lookup('env','PUBLIC_KEY')| default('~/.ssh/id_rsa.pub', true)) }}"
+    key: "{{ lookup('file', ansible_public_key_file) }}"
 
 - name: Setup tripleo directories
   file:

--- a/vars/deploy.yml
+++ b/vars/deploy.yml
@@ -1,4 +1,9 @@
 ---
+# The path to the public key to use in this automation.
+ansible_public_key_file: "{{ lookup('env', 'PUBLIC_KEY')|default('~/.ssh/id_rsa.pub', true) }}"
+# The path to the private key to access servers using the keypair.
+ansible_private_key_file: "{{ lookup('env', 'PRIVATE_KEY')|default('~/.ssh/id_rsa', true) }}"
+
 ####################################################################################################
 # OpenStack Version/Build Variables
 ####################################################################################################
@@ -18,6 +23,15 @@ container_tag: "{{ lookup('env', 'OSP_CONTAINER_TAG')|default('2018-06-21.2', tr
 container_ceph_namespace: "{{ lookup('env', 'OSP_CONTAINER_CEPH_NAMESPACE')|default('', true) }}"
 container_ceph_image: "{{ lookup('env', 'OSP_CONTAINER_CEPH_IMAGE')|default('rhceph', true) }}"
 container_ceph_tag: "{{ lookup('env', 'OSP_CONTAINER_CEPH_TAG')|default('3-9', true) }}"
+
+# The ceph pools pg values to adjust post-deploy.
+ceph_pools:
+  - pool_name: vms
+    pg_num: "{{ lookup('env', 'OSP_CEPH_POOL_VM_PG_NUM')|default('512', true) }}"
+  - pool_name: images
+    pg_num: "{{ lookup('env', 'OSP_CEPH_POOL_IMAGES_PG_NUM')|default('128', true) }}"
+  - pool_name: volumes
+    pg_num: "{{ lookup('env', 'OSP_CEPH_POOL_VOLUMES_PG_NUM')|default('128', true) }}"
 
 ####################################################################################################
 # Undercloud Variables


### PR DESCRIPTION
This is the work to add some post deployment tasks to configure ceph pg and pgp numbers.

This required adding the overcloud machines to the in memory host list.

Renamed the `scalelab-network` role to `post-deploy` but github did not pick that up.

