### PR TITLE
Changing the vlan clean procedure and adding motd template.

### DIFF
--- a/roles/undercloud-prepare-host/tasks/main.yml
+++ b/roles/undercloud-prepare-host/tasks/main.yml
@@ -1,14 +1,26 @@
 ---
 # tasks file for undercloud-prep
 
+- name: Create the message of the day (motd) file
+  template:
+    backup: yes
+    src: motd.j2
+    dest: /etc/motd
+
+- name: Make sure the motd is displayed when using ssh
+  lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: "^PrintMotd.*"
+    line: "PrintMotd yes"
+
 # Scale Lab Pre-deployment tooling lays down vlans to test network before hand
 # Lets remove this to avoid confusion when debugging and to prevent vlan conflicts
-- name: Clean Validation vlans
+- name: Clean validation vlans
   shell: |
-    for interface in $(ip -o link show | awk '{print $2}' | grep "@"  | awk '{split($0,interface,"@"); print interface[1]}')
+    for f in $(grep IPADDR=172 /etc/sysconfig/network-scripts/* | awk -F: '{ print $1 }');
     do
-      ifdown ${interface}
-      rm /etc/sysconfig/network-scripts/ifcfg-${interface}
+      ifdown $(basename $f | awk -F- '{ print $2 }')
+      rm -f $f
     done
 
 - name: Disable epel

--- a/roles/undercloud-prepare-host/templates/motd.j2
+++ b/roles/undercloud-prepare-host/templates/motd.j2
@@ -1,0 +1,5 @@
+Welcome to OpenStack {{ version }} running on RHEL {{ rhel_version }}!
+
+Using the {{ build }} build of Red Hat OpenStack {{ rhos_release }}.
+
+{{ undercloud_hostname }} is the undercloud for the {{ clusterid }} OpenShift cluster.

--- a/vars/deploy.yml
+++ b/vars/deploy.yml
@@ -27,6 +27,7 @@ container_ceph_tag: "{{ lookup('env', 'OSP_CONTAINER_CEPH_TAG')|default('3-9', t
 ####################################################################################################
 # Undercloud Variables
 ####################################################################################################
+clusterid: "{{ lookup('env', 'OSP_CLUSTER_ID')|default('alderaan', true)}}"
 rebuild_undercloud: "{{ lookup('env', 'OSP_REBUILD_UNDERCLOUD')|default(true, true) }}"
 undercloud_hostname: "{{ lookup('env', 'OSP_UNDERCLOUD_HOSTNAME') }}"
 ticket_number: "{{ lookup('env', 'OSP_QUADS_TICKET_NUMBER') }}"


### PR DESCRIPTION
Using the bash code from `clean-interfaces.sh` so we don't rely on a file that is outside of this process to clean VLANs.

Also adding a template for the Message of the Day (motd). To give the users information about the environment.