### PR TITLE
Raise Nova Max Scheduler Attempts

### DIFF
--- a/roles/overcloud-prepare-templates/files/controller-params.yaml
+++ b/roles/overcloud-prepare-templates/files/controller-params.yaml
@@ -2,6 +2,7 @@ parameter_defaults:
   HeatMaxResourcesPerStack: -1
   NovaSchedulerDefaultFilters: ['RetryFilter','AvailabilityZoneFilter','RamFilter','DiskFilter','ComputeFilter','ComputeCapabilitiesFilter','ImagePropertiesFilter','ServerGroupAntiAffinityFilter','ServerGroupAffinityFilter','PciPassthroughFilter']
   NovaSchedulerAvailableFilters: ['nova.scheduler.filters.all_filters']
+  NovaSchedulerMaxAttempts: 10
   ControllerExtraConfig:
     nova::api::pci_alias:
       - name: 'nvme'


### PR DESCRIPTION
In the staging environment, we have a limited set of compute nodes
in which it is possible to encounter a race condition where as an
instance requiring PCI passthrough NVMe hits MaxRetriesExceeded.

Raising the number of possible attempts in order to increase likely
hood of successful instance booting in the staging environment with
PCI passthrough.