### PR TITLE
Update motd with a message rather than just User and Email

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,15 +112,15 @@ BROWBEAT_COLLECTD_RABBITMQ
 BROWBEAT_COLLECTD_CEPH
 ```
 
-## Updating User on Cluster
+## Updating motd on Cluster
 
 From CLI
 
 ```
 $ cp hosts.example hosts
 $ # Add Undercloud host to hosts
-$ # Edit vars in vars/update-user.yml or define Environment vars
-$ ansible-playbook -i hosts update-user.yaml
+$ # Edit vars in vars/update-cluster-motd.yml or define Environment vars
+$ ansible-playbook -i hosts update-cluster-motd.yaml
 ```
 
 If as a Jenkins Job, define the following parameters:
@@ -135,6 +135,5 @@ PRIVATE_KEY
 # Cluster User parameters
 #
 OCP_ON_OSP_CLUSTER_ID
-OCP_ON_OSP_USER
-OCP_ON_OSP_EMAIL
+OCP_ON_OSP_MESSAGE
 ```

--- a/update-cluster-motd.yaml
+++ b/update-cluster-motd.yaml
@@ -1,16 +1,16 @@
 ---
 #
-# Playbook to update who is using the OCP on OSP cluster
+# Playbook to update a motd on the OSP and OCP clusters
 #
 
-- name: Get OCP Cluster and set current user on OSP Cluster
+- name: Get OCP Cluster and set motd on OSP cluster
   hosts: undercloud
   gather_facts: false
   remote_user: stack
   vars:
     ocp_core_cluster: []
   vars_files:
-    - vars/update-user.yml
+    - vars/update-cluster-motd.yml
   pre_tasks:
     - name: Get ansible-host FIP
       shell: |
@@ -66,16 +66,12 @@
       changed_when: false
 
   roles:
-    - name: update-motd
-      vars:
-        update_motd: "{{ocp_on_osp_user}} / {{ocp_on_osp_email}} is using the cluster"
+    - update-motd
 
-- name: Update the OCP cluster with the current user
+- name: Update the OCP cluster with the current motd
   hosts: bastion, master, infra, cns, app_node, lb
   gather_facts: false
   vars_files:
-    - vars/update-user.yml
+    - vars/update-cluster-motd.yml
   roles:
-    - name: update-motd
-      vars:
-        update_motd: "{{ocp_on_osp_user}} / {{ocp_on_osp_email}} is using the cluster"
+    - update-motd

--- a/vars/update-cluster-motd.yml
+++ b/vars/update-cluster-motd.yml
@@ -1,10 +1,8 @@
 ---
-# update-user vars
+# update-cluster-motd vars
 
 ansible_public_key_file: "{{ lookup('env', 'PUBLIC_KEY')}}"
 ansible_private_key_file: "{{ lookup('env', 'PRIVATE_KEY')}}"
 
 clusterid: "{{ lookup('env', 'OCP_ON_OSP_CLUSTER_ID')}}"
-
-ocp_on_osp_user: "{{ lookup('env', 'OCP_ON_OSP_USER')}}"
-ocp_on_osp_email: "{{ lookup('env', 'OCP_ON_OSP_EMAIL')}}"
+update_motd: "{{ lookup('env', 'OCP_ON_OSP_MESSAGE')}}"


### PR DESCRIPTION
In hindsight, lets just choose a message rather than User/Email so we can state the cluster is free after usage or other scenarios too.